### PR TITLE
feat(setup): add Snowflake infrastructure provisioning scripts

### DIFF
--- a/profiles.yml.example
+++ b/profiles.yml.example
@@ -1,0 +1,77 @@
+# =============================================================================
+# TORONTO MOBILITY ANALYTICS: dbt PROFILES CONFIGURATION TEMPLATE
+# =============================================================================
+# DO NOT COMMIT THIS FILE WITH REAL CREDENTIALS
+# Copy to ~/.dbt/profiles.yml or project root and replace placeholders
+# Store actual credentials in environment variables or secure vault
+# =============================================================================
+
+toronto_mobility:
+  target: dev
+  outputs:
+    # -------------------------------------------------------------------------
+    # LOCAL DEVELOPMENT
+    # -------------------------------------------------------------------------
+    # For interactive development with personal Snowflake credentials
+    # Uses TRANSFORMER_ROLE for dbt model development
+    # -------------------------------------------------------------------------
+    dev:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"  # e.g., xy12345.us-east-1
+      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      role: TRANSFORMER_ROLE
+      database: TORONTO_MOBILITY
+      warehouse: TRANSFORM_WH
+      schema: MARTS
+      threads: 4
+
+    # -------------------------------------------------------------------------
+    # CI/CD PIPELINE
+    # -------------------------------------------------------------------------
+    # For automated builds in GitHub Actions
+    # Uses TRANSFORMER_SVC service account
+    # -------------------------------------------------------------------------
+    ci:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: TRANSFORMER_SVC
+      password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      role: TRANSFORMER_ROLE
+      database: TORONTO_MOBILITY
+      warehouse: TRANSFORM_WH
+      schema: MARTS
+      threads: 4
+
+    # -------------------------------------------------------------------------
+    # DATA INGESTION
+    # -------------------------------------------------------------------------
+    # For Python ingestion scripts (COPY INTO operations)
+    # Uses LOADER_SVC service account with RAW schema access
+    # -------------------------------------------------------------------------
+    loader:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: LOADER_SVC
+      password: "{{ env_var('SNOWFLAKE_LOADER_PASSWORD') }}"
+      role: LOADER_ROLE
+      database: TORONTO_MOBILITY
+      warehouse: TRANSFORM_WH
+      schema: RAW
+      threads: 2
+
+# =============================================================================
+# ENVIRONMENT VARIABLE REFERENCE
+# =============================================================================
+# Required environment variables (set in shell or GitHub Secrets):
+#
+#   SNOWFLAKE_ACCOUNT         Snowflake account identifier (e.g., xy12345.us-east-1)
+#   SNOWFLAKE_USER            Username for dev target (your personal user)
+#   SNOWFLAKE_PASSWORD        Password for TRANSFORMER_SVC (CI) or personal user (dev)
+#   SNOWFLAKE_LOADER_PASSWORD Password for LOADER_SVC (ingestion scripts)
+#
+# GitHub Secrets Configuration:
+#   - SNOWFLAKE_ACCOUNT
+#   - SNOWFLAKE_PASSWORD (TRANSFORMER_SVC password)
+#   - SNOWFLAKE_LOADER_PASSWORD (LOADER_SVC password)
+# =============================================================================

--- a/setup/grants.sql
+++ b/setup/grants.sql
@@ -1,0 +1,119 @@
+-- =============================================================================
+-- TORONTO MOBILITY ANALYTICS: ROLE-BASED ACCESS CONTROL CONFIGURATION
+-- =============================================================================
+-- Epic: E-201 Snowflake Infrastructure Provisioning
+-- Execution Context: SECURITYADMIN for roles/users, SYSADMIN for grants
+-- Idempotent: Yes (IF NOT EXISTS patterns, grants are additive)
+-- Prerequisite: snowflake_init.sql must be executed first
+-- =============================================================================
+
+-- =============================================================================
+-- SECTION 1: ROLE CREATION
+-- =============================================================================
+-- LOADER_ROLE: Owns RAW schema, performs data ingestion via COPY INTO
+-- TRANSFORMER_ROLE: Owns transform schemas, executes dbt builds
+-- Both roles granted to SYSADMIN for administrative oversight
+-- =============================================================================
+USE ROLE SECURITYADMIN;
+
+CREATE ROLE IF NOT EXISTS LOADER_ROLE
+    COMMENT = 'Data ingestion role - owns RAW schema objects';
+
+CREATE ROLE IF NOT EXISTS TRANSFORMER_ROLE
+    COMMENT = 'Transformation role - owns STAGING/INTERMEDIATE/MARTS/SEEDS objects';
+
+-- Grant roles to SYSADMIN for management hierarchy
+-- Enables SYSADMIN to manage objects created by these roles
+GRANT ROLE LOADER_ROLE TO ROLE SYSADMIN;
+GRANT ROLE TRANSFORMER_ROLE TO ROLE SYSADMIN;
+
+-- =============================================================================
+-- SECTION 2: WAREHOUSE GRANTS
+-- =============================================================================
+-- Both roles require warehouse access for query execution
+-- =============================================================================
+USE ROLE SYSADMIN;
+
+GRANT USAGE ON WAREHOUSE TRANSFORM_WH TO ROLE LOADER_ROLE;
+GRANT USAGE ON WAREHOUSE TRANSFORM_WH TO ROLE TRANSFORMER_ROLE;
+
+-- =============================================================================
+-- SECTION 3: DATABASE GRANTS
+-- =============================================================================
+-- Both roles require database-level USAGE to access schemas
+-- =============================================================================
+GRANT USAGE ON DATABASE TORONTO_MOBILITY TO ROLE LOADER_ROLE;
+GRANT USAGE ON DATABASE TORONTO_MOBILITY TO ROLE TRANSFORMER_ROLE;
+
+-- =============================================================================
+-- SECTION 4: LOADER_ROLE SCHEMA GRANTS
+-- =============================================================================
+-- LOADER_ROLE has full control of RAW schema for data ingestion
+-- Includes current and future table privileges for COPY INTO operations
+-- =============================================================================
+GRANT ALL PRIVILEGES ON SCHEMA TORONTO_MOBILITY.RAW TO ROLE LOADER_ROLE;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA TORONTO_MOBILITY.RAW TO ROLE LOADER_ROLE;
+GRANT ALL PRIVILEGES ON FUTURE TABLES IN SCHEMA TORONTO_MOBILITY.RAW TO ROLE LOADER_ROLE;
+
+-- =============================================================================
+-- SECTION 5: TRANSFORMER_ROLE SCHEMA GRANTS
+-- =============================================================================
+-- RAW schema: Read-only access for source data consumption
+-- Transform schemas: Full control for dbt model creation
+-- =============================================================================
+
+-- RAW schema: Read-only (prevents accidental source data corruption)
+GRANT USAGE ON SCHEMA TORONTO_MOBILITY.RAW TO ROLE TRANSFORMER_ROLE;
+GRANT SELECT ON ALL TABLES IN SCHEMA TORONTO_MOBILITY.RAW TO ROLE TRANSFORMER_ROLE;
+GRANT SELECT ON FUTURE TABLES IN SCHEMA TORONTO_MOBILITY.RAW TO ROLE TRANSFORMER_ROLE;
+
+-- STAGING schema: Full control for view creation
+GRANT ALL PRIVILEGES ON SCHEMA TORONTO_MOBILITY.STAGING TO ROLE TRANSFORMER_ROLE;
+GRANT ALL PRIVILEGES ON FUTURE TABLES IN SCHEMA TORONTO_MOBILITY.STAGING TO ROLE TRANSFORMER_ROLE;
+GRANT ALL PRIVILEGES ON FUTURE VIEWS IN SCHEMA TORONTO_MOBILITY.STAGING TO ROLE TRANSFORMER_ROLE;
+
+-- INTERMEDIATE schema: Full control (ephemeral models compile as CTEs, schema exists for routing)
+GRANT ALL PRIVILEGES ON SCHEMA TORONTO_MOBILITY.INTERMEDIATE TO ROLE TRANSFORMER_ROLE;
+
+-- MARTS schema: Full control for fact/dimension table creation
+GRANT ALL PRIVILEGES ON SCHEMA TORONTO_MOBILITY.MARTS TO ROLE TRANSFORMER_ROLE;
+GRANT ALL PRIVILEGES ON FUTURE TABLES IN SCHEMA TORONTO_MOBILITY.MARTS TO ROLE TRANSFORMER_ROLE;
+
+-- SEEDS schema: Full control for dbt seed operations
+GRANT ALL PRIVILEGES ON SCHEMA TORONTO_MOBILITY.SEEDS TO ROLE TRANSFORMER_ROLE;
+GRANT ALL PRIVILEGES ON FUTURE TABLES IN SCHEMA TORONTO_MOBILITY.SEEDS TO ROLE TRANSFORMER_ROLE;
+
+-- =============================================================================
+-- SECTION 6: SERVICE ACCOUNT CREATION
+-- =============================================================================
+-- Service accounts for automated pipelines (CI/CD, ingestion scripts)
+-- Passwords must be replaced with secure generated values before execution
+-- Store actual passwords in GitHub Secrets, never in repository
+-- =============================================================================
+USE ROLE SECURITYADMIN;
+
+CREATE USER IF NOT EXISTS LOADER_SVC
+    PASSWORD = '<GENERATED_PASSWORD>'
+    DEFAULT_ROLE = LOADER_ROLE
+    DEFAULT_WAREHOUSE = TRANSFORM_WH
+    MUST_CHANGE_PASSWORD = FALSE
+    COMMENT = 'Service account for data ingestion pipelines';
+
+CREATE USER IF NOT EXISTS TRANSFORMER_SVC
+    PASSWORD = '<GENERATED_PASSWORD>'
+    DEFAULT_ROLE = TRANSFORMER_ROLE
+    DEFAULT_WAREHOUSE = TRANSFORM_WH
+    MUST_CHANGE_PASSWORD = FALSE
+    COMMENT = 'Service account for dbt transformations and CI/CD';
+
+-- Grant roles to service accounts
+GRANT ROLE LOADER_ROLE TO USER LOADER_SVC;
+GRANT ROLE TRANSFORMER_ROLE TO USER TRANSFORMER_SVC;
+
+-- =============================================================================
+-- VERIFICATION: Confirm role and grant configuration
+-- =============================================================================
+SHOW ROLES LIKE '%_ROLE';
+SHOW USERS LIKE '%_SVC';
+SHOW GRANTS TO ROLE LOADER_ROLE;
+SHOW GRANTS TO ROLE TRANSFORMER_ROLE;

--- a/setup/snowflake_init.sql
+++ b/setup/snowflake_init.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- TORONTO MOBILITY ANALYTICS: SNOWFLAKE INFRASTRUCTURE INITIALIZATION
+-- =============================================================================
+-- Epic: E-201 Snowflake Infrastructure Provisioning
+-- Execution Context: SYSADMIN role required
+-- Idempotent: Yes (CREATE OR REPLACE / IF NOT EXISTS patterns)
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- PRE-EXECUTION: Set role context for object creation
+-- SYSADMIN owns infrastructure objects per Snowflake RBAC best practices
+-- -----------------------------------------------------------------------------
+USE ROLE SYSADMIN;
+
+-- -----------------------------------------------------------------------------
+-- DATABASE: TORONTO_MOBILITY
+-- Central container for all project schemas and objects
+-- -----------------------------------------------------------------------------
+CREATE DATABASE IF NOT EXISTS TORONTO_MOBILITY
+    COMMENT = 'Toronto Urban Mobility Analytics - Transit and cycling data warehouse';
+
+-- -----------------------------------------------------------------------------
+-- SCHEMAS: Medallion Architecture Implementation
+-- RAW: Landing zone for ingested source data (owned by LOADER_ROLE)
+-- STAGING: Renamed/typed views over RAW (owned by TRANSFORMER_ROLE)
+-- INTERMEDIATE: Ephemeral CTEs - schema exists for dbt routing only
+-- MARTS: Analytics-ready fact and dimension tables
+-- SEEDS: Reference data loaded via dbt seed
+-- -----------------------------------------------------------------------------
+CREATE SCHEMA IF NOT EXISTS TORONTO_MOBILITY.RAW
+    COMMENT = 'Landing zone for raw ingested data from Open Data Portal sources';
+
+CREATE SCHEMA IF NOT EXISTS TORONTO_MOBILITY.STAGING
+    COMMENT = 'Staging views with column renaming, type casting, and basic cleansing';
+
+CREATE SCHEMA IF NOT EXISTS TORONTO_MOBILITY.INTERMEDIATE
+    COMMENT = 'Intermediate layer for ephemeral models - no persistent objects';
+
+CREATE SCHEMA IF NOT EXISTS TORONTO_MOBILITY.MARTS
+    COMMENT = 'Analytics-ready fact and dimension tables for consumption';
+
+CREATE SCHEMA IF NOT EXISTS TORONTO_MOBILITY.SEEDS
+    COMMENT = 'Reference data tables loaded via dbt seed (delay codes, station mappings)';
+
+-- -----------------------------------------------------------------------------
+-- WAREHOUSE: TRANSFORM_WH
+-- X-Small sizing per DESIGN-DOC Section 10.1 performance requirements
+-- 60-second auto-suspend balances cost with responsiveness
+-- Initially suspended prevents unnecessary credit consumption at creation
+-- -----------------------------------------------------------------------------
+CREATE WAREHOUSE IF NOT EXISTS TRANSFORM_WH
+    WITH
+        WAREHOUSE_SIZE = 'XSMALL'
+        AUTO_SUSPEND = 60
+        AUTO_RESUME = TRUE
+        INITIALLY_SUSPENDED = TRUE
+        COMMENT = 'Transformation warehouse for dbt builds and analytics queries';
+
+-- -----------------------------------------------------------------------------
+-- VERIFICATION: Confirm object creation
+-- Execute these queries to validate successful infrastructure deployment
+-- -----------------------------------------------------------------------------
+SHOW DATABASES LIKE 'TORONTO_MOBILITY';
+SHOW SCHEMAS IN DATABASE TORONTO_MOBILITY;
+SHOW WAREHOUSES LIKE 'TRANSFORM_WH';

--- a/setup/validate_infrastructure.sql
+++ b/setup/validate_infrastructure.sql
@@ -1,0 +1,147 @@
+-- =============================================================================
+-- TORONTO MOBILITY ANALYTICS: INFRASTRUCTURE VALIDATION SCRIPT
+-- =============================================================================
+-- Epic: E-201 Snowflake Infrastructure Provisioning (Story S007)
+-- Execution Context: Run as TRANSFORMER_SVC to validate RBAC configuration
+-- Purpose: Verify complete infrastructure setup and role-based access control
+-- =============================================================================
+
+-- =============================================================================
+-- SECTION 1: SESSION CONTEXT VALIDATION
+-- =============================================================================
+-- Confirms the connection is using expected role and warehouse
+-- Expected results:
+--   CURRENT_ROLE() = 'TRANSFORMER_ROLE'
+--   CURRENT_WAREHOUSE() = 'TRANSFORM_WH'
+-- =============================================================================
+
+SELECT
+    CURRENT_ROLE() AS current_role,
+    CURRENT_WAREHOUSE() AS current_warehouse,
+    CURRENT_USER() AS current_user,
+    CURRENT_DATABASE() AS current_database,
+    CASE
+        WHEN CURRENT_ROLE() = 'TRANSFORMER_ROLE' THEN 'PASS'
+        ELSE 'FAIL: Expected TRANSFORMER_ROLE'
+    END AS role_check,
+    CASE
+        WHEN CURRENT_WAREHOUSE() = 'TRANSFORM_WH' THEN 'PASS'
+        ELSE 'FAIL: Expected TRANSFORM_WH'
+    END AS warehouse_check;
+
+-- =============================================================================
+-- SECTION 2: DATABASE ACCESS VALIDATION
+-- =============================================================================
+-- Confirms TRANSFORMER_ROLE can access the project database
+-- =============================================================================
+
+USE DATABASE TORONTO_MOBILITY;
+
+SELECT 'DATABASE_ACCESS' AS test_name, 'PASS' AS result;
+
+-- =============================================================================
+-- SECTION 3: TRANSFORM SCHEMA WRITE ACCESS VALIDATION
+-- =============================================================================
+-- Confirms TRANSFORMER_ROLE has CREATE TABLE privileges in transform schemas
+-- Creates and drops test objects to verify full write access
+-- =============================================================================
+
+-- STAGING schema write test
+USE SCHEMA STAGING;
+CREATE TABLE IF NOT EXISTS STAGING._VALIDATION_TEST (id INT);
+DROP TABLE IF EXISTS STAGING._VALIDATION_TEST;
+SELECT 'STAGING_WRITE_ACCESS' AS test_name, 'PASS' AS result;
+
+-- INTERMEDIATE schema write test
+USE SCHEMA INTERMEDIATE;
+CREATE TABLE IF NOT EXISTS INTERMEDIATE._VALIDATION_TEST (id INT);
+DROP TABLE IF EXISTS INTERMEDIATE._VALIDATION_TEST;
+SELECT 'INTERMEDIATE_WRITE_ACCESS' AS test_name, 'PASS' AS result;
+
+-- MARTS schema write test
+USE SCHEMA MARTS;
+CREATE TABLE IF NOT EXISTS MARTS._VALIDATION_TEST (id INT);
+DROP TABLE IF EXISTS MARTS._VALIDATION_TEST;
+SELECT 'MARTS_WRITE_ACCESS' AS test_name, 'PASS' AS result;
+
+-- SEEDS schema write test
+USE SCHEMA SEEDS;
+CREATE TABLE IF NOT EXISTS SEEDS._VALIDATION_TEST (id INT);
+DROP TABLE IF EXISTS SEEDS._VALIDATION_TEST;
+SELECT 'SEEDS_WRITE_ACCESS' AS test_name, 'PASS' AS result;
+
+-- =============================================================================
+-- SECTION 4: RAW SCHEMA READ ACCESS VALIDATION
+-- =============================================================================
+-- Confirms TRANSFORMER_ROLE has read access to RAW schema
+-- =============================================================================
+
+USE SCHEMA RAW;
+SELECT 'RAW_SCHEMA_ACCESS' AS test_name, 'PASS' AS result;
+
+-- =============================================================================
+-- SECTION 5: RAW SCHEMA WRITE RESTRICTION VALIDATION
+-- =============================================================================
+-- CRITICAL: This test MUST FAIL with insufficient privileges
+-- TRANSFORMER_ROLE should NOT have write access to RAW schema
+-- This enforces separation between ingestion and transformation layers
+--
+-- MANUAL VERIFICATION REQUIRED:
+-- Execute the following command and confirm it returns an error:
+--
+--     CREATE TABLE RAW._VALIDATION_TEST (id INT);
+--
+-- Expected error: "Insufficient privileges to operate on schema 'RAW'"
+-- If the command succeeds, RBAC configuration is INCORRECT
+-- =============================================================================
+
+SELECT
+    'RAW_WRITE_RESTRICTION' AS test_name,
+    'MANUAL_VERIFICATION_REQUIRED' AS result,
+    'Execute: CREATE TABLE RAW._VALIDATION_TEST (id INT); - must fail' AS instruction;
+
+-- =============================================================================
+-- SECTION 6: SCHEMA INVENTORY VALIDATION
+-- =============================================================================
+-- Confirms all required schemas exist in the database
+-- =============================================================================
+
+SELECT
+    SCHEMA_NAME,
+    CASE
+        WHEN SCHEMA_NAME IN ('RAW', 'STAGING', 'INTERMEDIATE', 'MARTS', 'SEEDS')
+        THEN 'REQUIRED'
+        ELSE 'SYSTEM'
+    END AS schema_type
+FROM TORONTO_MOBILITY.INFORMATION_SCHEMA.SCHEMATA
+ORDER BY
+    CASE SCHEMA_NAME
+        WHEN 'RAW' THEN 1
+        WHEN 'STAGING' THEN 2
+        WHEN 'INTERMEDIATE' THEN 3
+        WHEN 'MARTS' THEN 4
+        WHEN 'SEEDS' THEN 5
+        ELSE 6
+    END;
+
+-- =============================================================================
+-- SECTION 7: WAREHOUSE CONFIGURATION VALIDATION
+-- =============================================================================
+-- Confirms warehouse settings match DESIGN-DOC requirements
+-- =============================================================================
+
+SHOW WAREHOUSES LIKE 'TRANSFORM_WH';
+
+SELECT
+    'WAREHOUSE_CONFIG' AS test_name,
+    'Verify: SIZE=XSMALL, AUTO_SUSPEND=60, AUTO_RESUME=TRUE' AS expected_config;
+
+-- =============================================================================
+-- VALIDATION SUMMARY
+-- =============================================================================
+-- All tests in Sections 1-4, 6-7 should return PASS
+-- Section 5 requires manual verification that RAW write fails
+-- Infrastructure is validated when:
+--   - All automated tests pass
+--   - RAW write attempt fails with privilege error
+-- =============================================================================


### PR DESCRIPTION
## Summary

- Add `setup/snowflake_init.sql` with database, schema, and warehouse DDL for TORONTO_MOBILITY
- Add `setup/grants.sql` with LOADER_ROLE and TRANSFORMER_ROLE RBAC configuration
- Add `setup/validate_infrastructure.sql` for infrastructure verification
- Add `profiles.yml.example` for dbt connection template

## Linked Issue

Closes #4

## Change Type

- [x] feat — New feature or capability

## Design Impact

- **Architecture Layer**: Infrastructure (Snowflake objects)
- **Schema Changes**: Creates TORONTO_MOBILITY database with RAW, STAGING, INTERMEDIATE, MARTS, SEEDS schemas
- **New Objects**: TRANSFORM_WH warehouse, LOADER_ROLE, TRANSFORMER_ROLE, LOADER_SVC, TRANSFORMER_SVC

## Testing Evidence

Infrastructure validated in Snowflake:
- Database and 5 schemas created successfully
- TRANSFORM_WH warehouse (X-Small, 60s auto-suspend) operational
- TRANSFORMER_ROLE can create/drop objects in STAGING, INTERMEDIATE, MARTS, SEEDS
- TRANSFORMER_ROLE cannot write to RAW (read-only access confirmed)
- Service accounts created with correct default roles

## Risk Assessment

**Low** — Infrastructure-only changes with no production data impact. Scripts are idempotent and safe to re-run.

## Governance Checklist

- [x] Follows CLAUDE.md Section 11 standards
- [x] No credentials committed (passwords use placeholders)
- [x] No AI attribution artifacts
- [x] Commit message follows Conventional Commits