### PR TITLE
fix(ci): trigger CI Lint on any workflow file change

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -14,7 +14,7 @@ on:
       - "pyproject.toml"
       - "requirements*.txt"
       - ".sqlfluff"
-      - ".github/workflows/ci-lint.yml"
+      - ".github/workflows/**"
   push:
     branches: [main]
     paths:
@@ -28,7 +28,7 @@ on:
       - "pyproject.toml"
       - "requirements*.txt"
       - ".sqlfluff"
-      - ".github/workflows/ci-lint.yml"
+      - ".github/workflows/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Expand CI Lint workflow path trigger to include all workflow files (`.github/workflows/**`).

## Problem

The `detect-changes` job is a required status check but wasn't running on PRs that only modify workflow files outside of `ci-lint.yml` (e.g., PR #6 which only changes `ci-dbt.yml`).

## Solution

Change path trigger from `.github/workflows/ci-lint.yml` to `.github/workflows/**` to match the pattern used in `ci-python.yml` and `ci-dbt.yml`.

## Linked Issue

Fixes blocking merge status on PRs #6, #7, #8 (dependabot updates).

## Change Type

- [x] Bug fix

## Risk Assessment

**Low** - CI trigger scope expansion only.