### PR TITLE
fix(ci): trigger all CI workflows on docs changes

### DIFF
--- a/.github/workflows/ci-dbt.yml
+++ b/.github/workflows/ci-dbt.yml
@@ -13,6 +13,7 @@ on:
       - "packages.yml"
       - "profiles.yml.example"
       - ".github/workflows/**"
+      - "docs/**"
   push:
     branches: [main]
     paths:
@@ -25,6 +26,7 @@ on:
       - "packages.yml"
       - "profiles.yml.example"
       - ".github/workflows/**"
+      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -15,6 +15,7 @@ on:
       - "requirements*.txt"
       - ".sqlfluff"
       - ".github/workflows/**"
+      - "docs/**"
   push:
     branches: [main]
     paths:
@@ -29,6 +30,7 @@ on:
       - "requirements*.txt"
       - ".sqlfluff"
       - ".github/workflows/**"
+      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -11,6 +11,7 @@ on:
       - "setup.py"
       - "setup.cfg"
       - ".github/workflows/**"
+      - "docs/**"
   push:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - "setup.py"
       - "setup.cfg"
       - ".github/workflows/**"
+      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Add `docs/**` to path triggers for all CI workflows so required status checks run on docs-only PRs.

## Problem

PR #11 (docs-only change) is blocked because required checks (`detect-changes`, `detect-python`, `detect-dbt`) never run - the workflows don't trigger on `docs/**` paths.

## Solution

Add `docs/**` to path triggers in:
- `ci-lint.yml`
- `ci-python.yml`  
- `ci-dbt.yml`

## Change Type

- [x] Bug fix