### PR TITLE
docs(epics): add PH-03 data ingestion pipeline epics

### DIFF
--- a/docs/PH-03/data_download_E-301.md
+++ b/docs/PH-03/data_download_E-301.md
@@ -1,0 +1,250 @@
+# Data Download & Source Acquisition
+
+| Field        | Value                      |
+| ------------ | -------------------------- |
+| Epic ID      | E-301                      |
+| Phase        | PH-03                      |
+| Owner        | @dinesh-git17              |
+| Status       | Draft                      |
+| Dependencies | [PH-02.E-201, PH-02.E-202] |
+| Created      | 2026-02-03                 |
+
+## Context
+
+PH-03 requires raw source data from the Toronto Open Data Portal and Environment Canada before any schema validation or Snowflake loading can occur. The ingestion pipeline depends on reliable, repeatable acquisition of five distinct datasets: TTC subway delays, TTC bus delays, TTC streetcar delays, Bike Share ridership, and daily weather observations from Toronto Pearson (Station ID: 51459). These datasets span 2019-present and exist as a mix of XLSX and CSV files distributed across monthly and quarterly release cadences. Without a deterministic download mechanism, subsequent pipeline stages (validation, transformation, loading) have no input, making this epic the critical-path entry point for PH-03.
+
+## Scope
+
+### In Scope
+
+- Python 3.12 `scripts/download.py` module for fetching all five source datasets from Toronto Open Data Portal and Environment Canada
+- HTTP client implementation with retry logic, timeout configuration, and rate-limit awareness for Toronto Open Data CKAN API
+- File storage management under `data/raw/` with deterministic directory structure organized by source and year
+- Download manifest tracking (file URL, expected filename, download timestamp, byte size, HTTP status) for audit and idempotency
+- Environment Canada Historical Weather CSV acquisition for Toronto Pearson (Station ID: 51459, Climate ID: 6158733)
+- Unit and integration tests for the download module via `pytest`
+- Type-annotated module passing `mypy --strict`
+- Linting compliance with `ruff check` and `ruff format`
+
+### Out of Scope
+
+- Schema validation of downloaded files (covered by E-302)
+- XLSX-to-CSV conversion (covered by E-302)
+- Snowflake COPY INTO or MERGE operations (covered by E-303)
+- Incremental or differential downloads (full re-download is acceptable for v1 data volumes)
+- Orchestration sequencing across download → validate → transform → load (covered by E-303)
+
+## Technical Approach
+
+### Architecture Decisions
+
+- **CKAN API for Toronto Open Data**: The Toronto Open Data Portal exposes a CKAN-based API. Use the `package_show` endpoint to resolve dataset resource URLs programmatically rather than hardcoding download links, which break when the portal publishes new monthly files. This aligns with DESIGN-DOC.md Section 4.1 source definitions.
+- **`httpx` over `requests`**: Use `httpx` as the HTTP client for HTTP/2 support, built-in retry via `httpx.Client(transport=httpx.HTTPTransport(retries=3))`, and async-ready architecture. Python 3.12 requirement (CLAUDE.md Section 6.3) makes `httpx` the idiomatic choice.
+- **Deterministic directory layout**: Store files under `data/raw/<source>/<year>/` (e.g., `data/raw/ttc_subway/2023/`). This structure supports year-level partitioning for selective re-ingestion without full re-download.
+- **Idempotent downloads**: If a file already exists at the target path with matching byte size from a prior manifest entry, skip the download. This prevents redundant network traffic during iterative development.
+- **Environment Canada direct CSV**: Weather data is fetched via direct CSV download from `climate.weather.gc.ca` using query parameters for station ID, year, month, and data format. No API wrapper exists; construct URLs programmatically.
+
+### Integration Points
+
+- Toronto Open Data Portal CKAN API (`https://ckan0.cf.opendata.inter.prod-toronto.ca`)
+- Environment Canada Historical Climate Data (`https://climate.weather.gc.ca`)
+- Local filesystem `data/raw/` directory (gitignored)
+- Downstream: E-302 `validate.py` consumes files written by this module
+
+### Repository Areas
+
+- `scripts/download.py` — core download module
+- `scripts/config.py` — dataset registry (URLs, expected filenames, source metadata)
+- `tests/test_download.py` — unit and integration tests
+- `data/raw/` — download target directory (gitignored)
+- `pyproject.toml` — dependency declaration (`httpx`)
+
+### Risks
+
+| Risk                                                              | Likelihood | Impact | Mitigation                                                                                               |
+| ----------------------------------------------------------------- | ---------- | ------ | -------------------------------------------------------------------------------------------------------- |
+| Toronto Open Data Portal API changes resource URLs without notice | Medium     | High   | Resolve URLs dynamically via CKAN `package_show` rather than hardcoding; log resolved URLs for debugging |
+| Environment Canada rate-limits or blocks automated downloads      | Low        | Medium | Add 2-second delay between requests; implement exponential backoff; cache downloaded files locally       |
+| XLSX files exceed 100MB for bus delay annual aggregates           | Low        | Medium | Stream downloads with chunked writes; validate file size against manifest before proceeding              |
+| Network timeouts on large Bike Share CSV files (~500MB annual)    | Medium     | Medium | Configure 300-second timeout; implement resumable download via HTTP Range headers if server supports it  |
+
+## Stories
+
+| ID   | Story                                                 | Points | Dependencies | Status |
+| ---- | ----------------------------------------------------- | ------ | ------------ | ------ |
+| S001 | Create dataset configuration registry                 | 3      | None         | Draft  |
+| S002 | Implement Toronto Open Data CKAN download client      | 5      | S001         | Draft  |
+| S003 | Implement Environment Canada weather download client  | 3      | S001         | Draft  |
+| S004 | Implement download manifest and idempotency logic     | 3      | S002, S003   | Draft  |
+| S005 | Add comprehensive test suite for download module      | 5      | S002, S003   | Draft  |
+| S006 | Execute full source data acquisition for 2019-present | 3      | S004         | Draft  |
+
+---
+
+### S001: Create dataset configuration registry
+
+**Description**: Build a typed configuration module that defines all five source datasets with their API endpoints, expected file patterns, date ranges, and storage paths.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/config.py` exists and defines a `DatasetConfig` dataclass with fields: `name`, `source_type` (enum: `CKAN` | `ENVIRONMENT_CANADA`), `api_base_url`, `dataset_id` (for CKAN datasets), `station_id` (for weather), `year_range` (tuple of start/end year), `file_format` (enum: `XLSX` | `CSV`), `output_dir` (relative path under `data/raw/`)
+- [ ] Registry contains entries for all five datasets: `ttc_subway_delays`, `ttc_bus_delays`, `ttc_streetcar_delays`, `bike_share_ridership`, `weather_daily`
+- [ ] CKAN dataset IDs match Toronto Open Data Portal identifiers: subway (`996cfe8d-fb35-40ce-b569-698d51fc683b`), bus (`e271cdae-8788-4980-96ce-6a5c95bc6571`), streetcar (`b68cb71b-44a7-4394-97e2-5d2f41462a5d`), bike share (`7e876c24-177c-4605-9cef-e50dd74c617f`)
+- [ ] Environment Canada entry specifies Station ID `51459` and Climate ID `6158733`
+- [ ] `mypy --strict scripts/config.py` passes with zero errors
+- [ ] `ruff check scripts/config.py && ruff format --check scripts/config.py` passes
+
+**Technical Notes**: Use `enum.Enum` for source type and file format. Use `dataclasses.dataclass` with `frozen=True` for immutability. Store the registry as a module-level `DATASETS: tuple[DatasetConfig, ...]` constant.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S002: Implement Toronto Open Data CKAN download client
+
+**Description**: Build the core download function that resolves resource URLs from the CKAN API and downloads TTC delay and Bike Share files to the local filesystem.
+
+**Acceptance Criteria**:
+
+- [ ] Function `download_ckan_dataset(config: DatasetConfig, output_base: Path) -> list[DownloadResult]` exists in `scripts/download.py`
+- [ ] Function calls CKAN `package_show` API endpoint (`/api/3/action/package_show?id=<dataset_id>`) to resolve current resource URLs
+- [ ] Function filters resources by year range defined in `DatasetConfig` using resource metadata (name or date fields)
+- [ ] Downloads write to `data/raw/<source_name>/<year>/<original_filename>` preserving the portal's original filename
+- [ ] HTTP client uses `httpx.Client` with `timeout=300`, `transport=httpx.HTTPTransport(retries=3)`
+- [ ] Function returns a list of `DownloadResult` dataclass instances containing: `file_path`, `url`, `http_status`, `byte_size`, `download_timestamp`
+- [ ] On HTTP 4xx/5xx response, function raises `DownloadError` with the URL, status code, and response body
+- [ ] `mypy --strict scripts/download.py` passes with zero errors
+- [ ] `ruff check scripts/download.py && ruff format --check scripts/download.py` passes
+
+**Technical Notes**: The CKAN API returns a JSON response with `result.resources` array. Each resource has `url`, `name`, `last_modified`, and `format` fields. Filter resources by inspecting the `name` field for year indicators (e.g., "2023", "Jan 2023"). Create parent directories with `Path.mkdir(parents=True, exist_ok=True)` before writing.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S003: Implement Environment Canada weather download client
+
+**Description**: Build the download function for Environment Canada Historical Climate Data CSVs covering Toronto Pearson station from 2019 to present.
+
+**Acceptance Criteria**:
+
+- [ ] Function `download_weather_data(config: DatasetConfig, output_base: Path) -> list[DownloadResult]` exists in `scripts/download.py`
+- [ ] Function constructs download URLs using the pattern: `https://climate.weather.gc.ca/climate_data/bulk_data_e.html?format=csv&stationID=51459&Year={year}&Month={month}&timeframe=2` for each year-month combination in the configured range
+- [ ] Downloads one CSV per year (timeframe=2 returns daily data for the full year) and writes to `data/raw/weather/<year>/weather_daily_{year}.csv`
+- [ ] HTTP client uses `httpx.Client` with `timeout=120`, `transport=httpx.HTTPTransport(retries=3)`
+- [ ] Function inserts a 2-second delay (`time.sleep(2)`) between consecutive requests to respect rate limits
+- [ ] Function returns `DownloadResult` instances consistent with S002
+- [ ] On HTTP error, function raises `DownloadError` with URL, status code, and response body
+- [ ] `mypy --strict scripts/download.py` passes with zero errors
+
+**Technical Notes**: Environment Canada's bulk download endpoint returns CSV directly. The `timeframe=2` parameter selects daily granularity. Request one file per year rather than per month to reduce request count (7 requests for 2019-2025 vs. 84).
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S004: Implement download manifest and idempotency logic
+
+**Description**: Build a JSON-based manifest that tracks all downloaded files, enabling idempotent re-runs that skip previously acquired files.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/download.py` contains a `DownloadManifest` class that reads/writes a JSON manifest at `data/raw/.manifest.json`
+- [ ] Manifest schema contains a list of entries, each with: `url`, `file_path`, `byte_size`, `sha256_hash`, `download_timestamp`, `http_status`
+- [ ] Before downloading a file, the download functions (S002, S003) consult the manifest: if an entry exists with matching `url` and the file at `file_path` exists with matching `byte_size`, the download is skipped and logged as `SKIPPED`
+- [ ] After a successful download, the manifest is updated atomically (write to temp file, then `os.replace` to target path)
+- [ ] `DownloadManifest.prune()` method removes entries whose `file_path` no longer exists on disk
+- [ ] SHA-256 hash is computed for each downloaded file and stored in the manifest for integrity verification
+- [ ] `mypy --strict` passes on all modified files
+- [ ] `ruff check && ruff format --check` passes on all modified files
+
+**Technical Notes**: Use `hashlib.sha256` with chunked reads (64KB buffer) for hash computation to avoid loading large files into memory. The manifest file itself lives inside `data/raw/` which is gitignored.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S005: Add comprehensive test suite for download module
+
+**Description**: Build a pytest test suite covering the download module with mocked HTTP responses and filesystem assertions.
+
+**Acceptance Criteria**:
+
+- [ ] File `tests/test_download.py` exists with test functions covering: CKAN URL resolution, CKAN file download, weather URL construction, weather file download, manifest read/write, manifest idempotency skip, error handling on HTTP failures
+- [ ] Tests mock HTTP responses using `pytest-httpx` or `respx` — no real network calls during test execution
+- [ ] Tests use `tmp_path` fixture for all filesystem operations
+- [ ] Test for CKAN download verifies correct directory structure: `<output_base>/<source_name>/<year>/<filename>`
+- [ ] Test for manifest idempotency verifies that a second download call with existing manifest entry and file produces `SKIPPED` status
+- [ ] Test for HTTP 404 verifies `DownloadError` is raised with the correct URL and status code
+- [ ] Test for SHA-256 hash verifies computed hash matches known value for a test fixture file
+- [ ] `pytest tests/test_download.py -v` passes with zero failures
+- [ ] `mypy --strict tests/test_download.py` passes
+- [ ] `ruff check tests/test_download.py && ruff format --check tests/test_download.py` passes
+
+**Technical Notes**: Create a minimal CKAN API JSON response fixture in `tests/fixtures/ckan_package_show_response.json` for realistic mock data. Use `pytest.raises` for error path assertions.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S006: Execute full source data acquisition for 2019-present
+
+**Description**: Run the download module against all five production datasets, verify completeness of acquired files, and document the resulting file inventory.
+
+**Acceptance Criteria**:
+
+- [ ] Running `python scripts/download.py --all` downloads all TTC delay files (subway, bus, streetcar) for years 2019-2025 from Toronto Open Data Portal
+- [ ] Running `python scripts/download.py --all` downloads all Bike Share ridership files for years 2019-2025
+- [ ] Running `python scripts/download.py --all` downloads all Environment Canada daily weather CSVs for years 2019-2025
+- [ ] `data/raw/.manifest.json` contains entries for every downloaded file with valid SHA-256 hashes
+- [ ] Re-running `python scripts/download.py --all` completes without re-downloading existing files (idempotency verified via log output showing `SKIPPED` status)
+- [ ] Total downloaded file count per source matches expected: TTC subway (~72 files), TTC bus (~72 files), TTC streetcar (~72 files), Bike Share (~24-28 files), weather (~7 files)
+- [ ] No download errors in the execution log
+
+**Technical Notes**: Run this story on a machine with stable internet connectivity. Expected total download size is approximately 2-3 GB across all datasets. The CLI entry point uses `argparse` with `--all`, `--dataset <name>`, and `--year <YYYY>` flags for selective execution.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+## Exit Criteria
+
+This epic is complete when:
+
+- [ ] `scripts/download.py` and `scripts/config.py` exist, are type-annotated, and pass `mypy --strict`
+- [ ] All five datasets (TTC subway, TTC bus, TTC streetcar, Bike Share, weather) are downloaded to `data/raw/` with correct directory structure
+- [ ] Download manifest at `data/raw/.manifest.json` tracks all acquired files with SHA-256 hashes
+- [ ] Idempotent re-execution skips previously downloaded files
+- [ ] `pytest tests/test_download.py` passes with zero failures
+- [ ] `ruff check` and `ruff format` pass on all Python files in `scripts/` and `tests/`
+- [ ] Python code generated via `python-writing` skill

--- a/docs/PH-03/schema_validation_E-302.md
+++ b/docs/PH-03/schema_validation_E-302.md
@@ -1,0 +1,256 @@
+# Schema Validation & Data Transformation
+
+| Field        | Value         |
+| ------------ | ------------- |
+| Epic ID      | E-302         |
+| Phase        | PH-03         |
+| Owner        | @dinesh-git17 |
+| Status       | Draft         |
+| Dependencies | [E-301]       |
+| Created      | 2026-02-03    |
+
+## Context
+
+Raw source files acquired by E-301 arrive in heterogeneous formats (XLSX for TTC delays, CSV for Bike Share and weather) with no guarantee of schema stability across years. The Toronto Open Data Portal has historically changed column names, added columns, and altered data types between annual releases. DESIGN-DOC.md Section 4.3 mandates fail-fast schema enforcement: if the actual schema of a downloaded file deviates from the expected contract, the entire ingestion run must abort with zero partial loads. This epic builds the validation and transformation layer that sits between raw file acquisition (E-301) and Snowflake loading (E-303), ensuring only contract-compliant CSV data reaches the loading stage.
+
+## Scope
+
+### In Scope
+
+- Python 3.12 `scripts/validate.py` module implementing fail-fast schema contract enforcement per DESIGN-DOC.md Section 4.3
+- Schema contract definitions for all five source datasets as typed Python datastructures matching Section 4.3.1 (TTC Subway), 4.3.2 (Bike Share), and 4.3.3 (Weather) contracts
+- `SchemaValidationError` custom exception with structured error reporting (expected vs. actual columns, type mismatches, file path)
+- Python 3.12 `scripts/transform.py` module for XLSX-to-CSV conversion using `openpyxl`
+- Encoding normalization (detect and convert to UTF-8) for source CSVs with inconsistent encodings
+- Unit and integration tests for both modules via `pytest`
+- Type-annotated modules passing `mypy --strict`
+- Linting compliance with `ruff check` and `ruff format`
+
+### Out of Scope
+
+- Data quality checks beyond schema contract (value range validation, distribution analysis — covered by PH-08)
+- Row-level data cleansing or imputation (staging layer responsibility, PH-05)
+- Downloading source files (covered by E-301)
+- Loading validated CSVs into Snowflake (covered by E-303)
+- Business logic transformations (column renaming, type casting — staging layer, PH-05)
+
+## Technical Approach
+
+### Architecture Decisions
+
+- **Fail-fast, zero tolerance**: Per DESIGN-DOC.md Section 4.3 schema change policy, validation raises `SchemaValidationError` on the first file that deviates from the expected contract. The orchestrator (E-303) catches this and aborts the entire run. No partial processing occurs.
+- **Schema contracts as frozen dataclasses**: Define each dataset's expected schema as a `SchemaContract` dataclass containing: `required_columns` (ordered list of `ColumnContract` with name and dtype), `nullable_columns` (set of column names), and `row_validators` (optional per-row callables). This makes contracts version-controlled, diffable, and testable.
+- **`openpyxl` for XLSX conversion**: Use `openpyxl` in read-only mode for memory-efficient processing of large XLSX files (TTC bus delays can exceed 100K rows per file). Write output as UTF-8 CSV with `csv.writer`. Avoid `pandas` for conversion to minimize dependency footprint and control encoding explicitly.
+- **Two-phase validation**: Phase 1 validates column presence and ordering (structural). Phase 2 validates column data types by sampling the first 1,000 rows (type inference). Both phases must pass before a file is marked valid.
+- **Encoding detection via `charset-normalizer`**: Some older TTC XLSX exports produce CSVs with Windows-1252 encoding. Use `charset-normalizer` to detect encoding and transcode to UTF-8 before validation.
+
+### Integration Points
+
+- Upstream: Reads files from `data/raw/<source>/<year>/` written by E-301
+- Downstream: Writes validated CSV files to `data/validated/<source>/<year>/` for consumption by E-303 `load.py`
+- Schema contracts reference DESIGN-DOC.md Section 4.3.1 (TTC Subway), 4.3.2 (Bike Share), 4.3.3 (Weather)
+
+### Repository Areas
+
+- `scripts/validate.py` — schema validation module
+- `scripts/transform.py` — XLSX-to-CSV conversion module
+- `scripts/contracts.py` — schema contract definitions
+- `tests/test_validate.py` — validation test suite
+- `tests/test_transform.py` — transformation test suite
+- `tests/fixtures/` — sample XLSX and CSV files for testing
+- `data/validated/` — output directory for validated CSVs (gitignored)
+- `pyproject.toml` — dependency declarations (`openpyxl`, `charset-normalizer`)
+
+### Risks
+
+| Risk                                                                             | Likelihood | Impact | Mitigation                                                                                                                     |
+| -------------------------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| TTC source files change column ordering between years while keeping column names | High       | Medium | Validate column presence as a set (not ordered list) for structural check; validate ordering only as a warning                 |
+| Bike Share CSV files contain BOM (Byte Order Mark) characters                    | Medium     | Low    | Strip BOM bytes during encoding normalization before validation                                                                |
+| XLSX files contain multiple worksheets with data split across sheets             | Low        | High   | Document expected worksheet name per dataset in `SchemaContract`; raise `SchemaValidationError` if target worksheet is missing |
+| Large XLSX files (>200K rows) cause memory pressure during conversion            | Low        | Medium | Use `openpyxl` read-only mode with row-by-row streaming; never load entire workbook into memory                                |
+
+## Stories
+
+| ID   | Story                                                          | Points | Dependencies           | Status |
+| ---- | -------------------------------------------------------------- | ------ | ---------------------- | ------ |
+| S001 | Define schema contracts for all five source datasets           | 5      | None                   | Draft  |
+| S002 | Implement XLSX-to-CSV conversion module                        | 5      | None                   | Draft  |
+| S003 | Implement schema validation engine with fail-fast behavior     | 5      | S001                   | Draft  |
+| S004 | Implement encoding detection and normalization                 | 3      | None                   | Draft  |
+| S005 | Add comprehensive test suite for validation and transformation | 5      | S001, S002, S003, S004 | Draft  |
+| S006 | Validate all downloaded source files against contracts         | 3      | S005, E-301.S006       | Draft  |
+
+---
+
+### S001: Define schema contracts for all five source datasets
+
+**Description**: Build typed schema contract definitions for TTC subway delays, TTC bus delays, TTC streetcar delays, Bike Share ridership, and daily weather data matching DESIGN-DOC.md Section 4.3 specifications.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/contracts.py` exists and defines a `ColumnContract` dataclass with fields: `name` (str), `expected_dtype` (str, one of: `DATE`, `TIME`, `STRING`, `INTEGER`, `DECIMAL`, `TIMESTAMP`), `nullable` (bool)
+- [ ] File defines a `SchemaContract` dataclass with fields: `dataset_name` (str), `columns` (tuple of `ColumnContract`), `min_row_count` (int, used as sanity check)
+- [ ] TTC Subway contract matches DESIGN-DOC.md Section 4.3.1 exactly: 9 columns (`Date`, `Time`, `Day`, `Station`, `Code`, `Min Delay`, `Min Gap`, `Bound`, `Line`) with correct types and nullability
+- [ ] Bike Share contract matches DESIGN-DOC.md Section 4.3.2 exactly: 10 columns with correct types and nullability
+- [ ] Weather contract matches DESIGN-DOC.md Section 4.3.3 exactly: 5 key columns with correct types and nullability (additional Environment Canada columns are permitted and ignored)
+- [ ] TTC Bus and TTC Streetcar contracts define their expected column structures (Bus includes `Route`, `Direction`, `Location`; Streetcar includes `Route`, `Direction`, `Location`)
+- [ ] Module-level constant `CONTRACTS: dict[str, SchemaContract]` maps dataset names to their contracts
+- [ ] `mypy --strict scripts/contracts.py` passes with zero errors
+- [ ] `ruff check scripts/contracts.py && ruff format --check scripts/contracts.py` passes
+
+**Technical Notes**: TTC Bus and Streetcar schemas differ slightly from Subway (Route instead of Line, Location instead of Station). Verify actual column names by inspecting sample files from the 2023 and 2024 releases. Weather CSVs from Environment Canada contain 20+ columns; the contract should define the 5 required columns and allow additional columns to pass through.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S002: Implement XLSX-to-CSV conversion module
+
+**Description**: Build a streaming XLSX-to-CSV converter that processes TTC delay files (which arrive as XLSX) into UTF-8 CSV format for downstream validation and loading.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/transform.py` exists and defines function `convert_xlsx_to_csv(xlsx_path: Path, csv_path: Path, sheet_name: str | None = None) -> TransformResult`
+- [ ] `TransformResult` dataclass contains: `input_path`, `output_path`, `row_count`, `column_count`, `elapsed_seconds`
+- [ ] Function uses `openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)` for memory-efficient reading
+- [ ] Function writes output as UTF-8 CSV with `csv.writer` using `quoting=csv.QUOTE_MINIMAL`
+- [ ] If `sheet_name` is `None`, function reads the first (active) worksheet
+- [ ] If `sheet_name` is provided but does not exist in the workbook, function raises `TransformError` listing available sheet names
+- [ ] Function creates parent directories of `csv_path` with `Path.mkdir(parents=True, exist_ok=True)`
+- [ ] Function `batch_convert(source_dir: Path, output_dir: Path, file_pattern: str = "*.xlsx") -> list[TransformResult]` processes all matching XLSX files in a directory tree, preserving subdirectory structure
+- [ ] `mypy --strict scripts/transform.py` passes with zero errors
+- [ ] `ruff check scripts/transform.py && ruff format --check scripts/transform.py` passes
+
+**Technical Notes**: TTC XLSX files use the default sheet name (typically "Sheet1" or the dataset name). Use `wb.active` when `sheet_name` is None. Handle `openpyxl` returning `None` for empty cells by writing empty string to CSV. Close workbook explicitly after reading to release file handles.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S003: Implement schema validation engine with fail-fast behavior
+
+**Description**: Build the core validation engine that checks CSV files against schema contracts and raises `SchemaValidationError` on the first deviation.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/validate.py` exists and defines function `validate_file(csv_path: Path, contract: SchemaContract) -> ValidationResult`
+- [ ] `ValidationResult` dataclass contains: `file_path`, `dataset_name`, `is_valid` (bool), `row_count`, `column_count`, `errors` (list of `ValidationError`)
+- [ ] `SchemaValidationError` exception class contains: `file_path`, `expected_columns` (list of str), `actual_columns` (list of str), `mismatches` (list of str describing each deviation)
+- [ ] Structural validation checks: all required columns from the contract exist in the CSV header (case-insensitive comparison)
+- [ ] Structural validation identifies: missing columns, unexpected extra columns (logged as warning, not blocking), column name case mismatches
+- [ ] Type validation samples the first 1,000 data rows and verifies: DATE columns parse as dates, INTEGER columns contain only digits (or empty for nullable), DECIMAL columns parse as float, TIMESTAMP columns parse as timestamps
+- [ ] On first validation failure, function raises `SchemaValidationError` with the file path, expected schema, actual schema, and list of specific mismatches
+- [ ] Function `validate_dataset(dataset_dir: Path, contract: SchemaContract) -> list[ValidationResult]` validates all CSV files in a directory tree against a single contract, failing fast on first invalid file
+- [ ] `mypy --strict scripts/validate.py` passes with zero errors
+- [ ] `ruff check scripts/validate.py && ruff format --check scripts/validate.py` passes
+
+**Technical Notes**: Use `csv.DictReader` for header extraction. For type inference sampling, read 1,000 rows and apply regex-based type checks (`r'^\d{4}-\d{2}-\d{2}$'` for DATE, `r'^-?\d+$'` for INTEGER). Allow empty strings in nullable columns. Log validation progress to stderr for observability during long runs.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S004: Implement encoding detection and normalization
+
+**Description**: Build an encoding detection and normalization utility that converts source files with inconsistent encodings to UTF-8 before validation.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/transform.py` defines function `normalize_encoding(input_path: Path, output_path: Path | None = None) -> EncodingResult`
+- [ ] `EncodingResult` dataclass contains: `input_path`, `output_path`, `detected_encoding`, `confidence` (float 0-1), `byte_count`, `had_bom` (bool)
+- [ ] Function uses `charset-normalizer` library to detect source encoding with minimum confidence threshold of 0.7
+- [ ] If detected encoding is already UTF-8 with confidence >= 0.7, function copies file unchanged (or returns early if `output_path` is `None`)
+- [ ] If encoding is not UTF-8, function reads with detected encoding and writes as UTF-8 to `output_path` (or overwrites `input_path` if `output_path` is `None`)
+- [ ] Function strips UTF-8 BOM (`\xef\xbb\xbf`) and UTF-16 BOM if present at file start
+- [ ] If detection confidence is below 0.7, function raises `EncodingError` with the file path and top 3 encoding candidates
+- [ ] `mypy --strict scripts/transform.py` passes with zero errors
+
+**Technical Notes**: Install `charset-normalizer` (not `chardet` — it is unmaintained). Read files in binary mode for detection, then re-read with the detected encoding for transcoding. Process files in 1MB chunks to limit memory usage on large CSVs.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S005: Add comprehensive test suite for validation and transformation
+
+**Description**: Build pytest test suites covering schema validation, XLSX conversion, and encoding normalization with fixture files and edge cases.
+
+**Acceptance Criteria**:
+
+- [ ] File `tests/test_validate.py` exists with tests covering: valid CSV passes validation, missing required column raises `SchemaValidationError`, extra column logs warning but passes, type mismatch in sampled rows raises `SchemaValidationError`, nullable column with empty values passes, case-insensitive column matching works
+- [ ] File `tests/test_transform.py` exists with tests covering: XLSX-to-CSV produces correct row/column count, missing worksheet raises `TransformError`, encoding detection identifies UTF-8 correctly, Windows-1252 file is transcoded to UTF-8, BOM is stripped from output
+- [ ] Test fixtures exist at `tests/fixtures/`: `valid_subway_delays.csv` (10 rows matching TTC subway contract), `invalid_missing_column.csv` (subway data with "Station" column removed), `valid_delays.xlsx` (small XLSX with 10 rows), `windows_1252.csv` (file with Windows-1252 encoding)
+- [ ] All tests use `tmp_path` fixture for filesystem operations — no writes to project directories
+- [ ] `pytest tests/test_validate.py tests/test_transform.py -v` passes with zero failures
+- [ ] `mypy --strict tests/test_validate.py tests/test_transform.py` passes
+- [ ] `ruff check tests/ && ruff format --check tests/` passes on test files
+
+**Technical Notes**: Generate XLSX fixtures programmatically in a `conftest.py` using `openpyxl` to avoid committing binary files. For encoding fixtures, encode a known UTF-8 string as Windows-1252 bytes and write to `tmp_path`.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S006: Validate all downloaded source files against contracts
+
+**Description**: Execute the validation pipeline against the full set of downloaded files from E-301, confirming all files pass schema contracts before proceeding to Snowflake loading.
+
+**Acceptance Criteria**:
+
+- [ ] Running `python scripts/validate.py --all --source-dir data/raw --output-dir data/validated` processes all downloaded files
+- [ ] All TTC XLSX files are converted to CSV via `transform.py` before validation
+- [ ] All converted CSVs and original CSVs (Bike Share, weather) pass schema validation against their respective contracts
+- [ ] `data/validated/` directory contains only validated, UTF-8 encoded CSV files organized as `data/validated/<source>/<year>/<filename>.csv`
+- [ ] Validation summary logged to stdout reports: total files processed, files passed, files failed (must be zero), total rows across all files
+- [ ] If any file fails validation, the process exits with code 1 and logs the `SchemaValidationError` details including file path and specific mismatches
+- [ ] Re-running validation on already-validated files in `data/validated/` produces identical results (idempotent)
+
+**Technical Notes**: The CLI entry point uses `argparse` with `--all`, `--dataset <name>`, `--source-dir <path>`, and `--output-dir <path>` flags. Wire up the encoding normalization step between XLSX conversion and schema validation. Log per-file progress to stderr for observability.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+## Exit Criteria
+
+This epic is complete when:
+
+- [ ] `scripts/validate.py`, `scripts/transform.py`, and `scripts/contracts.py` exist, are type-annotated, and pass `mypy --strict`
+- [ ] Schema contracts for all five datasets match DESIGN-DOC.md Section 4.3 specifications
+- [ ] All downloaded source files pass schema validation with zero failures
+- [ ] XLSX files are converted to UTF-8 CSV format
+- [ ] `SchemaValidationError` is raised and ingestion aborts on any schema deviation (fail-fast verified by test)
+- [ ] `pytest tests/test_validate.py tests/test_transform.py` passes with zero failures
+- [ ] `ruff check` and `ruff format` pass on all Python files
+- [ ] Python code generated via `python-writing` skill

--- a/docs/PH-03/snowflake_loading_E-303.md
+++ b/docs/PH-03/snowflake_loading_E-303.md
@@ -1,0 +1,294 @@
+# Snowflake Loading & Pipeline Orchestration
+
+| Field        | Value           |
+| ------------ | --------------- |
+| Epic ID      | E-303           |
+| Phase        | PH-03           |
+| Owner        | @dinesh-git17   |
+| Status       | Draft           |
+| Dependencies | [E-301, E-302]  |
+| Created      | 2026-02-03      |
+
+## Context
+
+With source files downloaded (E-301) and validated against schema contracts (E-302), the final stage of PH-03 loads data into the Snowflake RAW schema. DESIGN-DOC.md mandates atomic transaction semantics: the Snowflake warehouse must never contain partial or corrupt data from a failed ingestion run. Loading uses Snowflake's `COPY INTO` for bulk ingestion and `MERGE` for idempotent upserts, ensuring repeated executions produce identical results. This epic also builds the top-level orchestrator (`ingest.py`) that sequences download → validate → transform → load as a single atomic pipeline, and executes the initial load populating all five RAW schema tables with 2019-present data. The exit criterion for PH-03 as a whole — RAW schema tables populated with row counts validated against source files within 1% tolerance — is verified in this epic.
+
+## Scope
+
+### In Scope
+
+- Python 3.12 `scripts/load.py` module implementing Snowflake `COPY INTO` via internal stage and `MERGE` for idempotent loading
+- Python 3.12 `scripts/ingest.py` orchestrator sequencing: download → transform → validate → load with atomic transaction semantics
+- Snowflake internal stage creation (`@TORONTO_MOBILITY.RAW.INGESTION_STAGE`) for file upload
+- `PUT` command execution to upload validated CSVs to internal stage
+- `COPY INTO` execution for bulk loading from stage to RAW tables
+- `MERGE` statement implementation using natural keys for idempotent upsert behavior
+- Atomic transaction control: `BEGIN` / `COMMIT` / `ROLLBACK` wrapping the full load sequence per dataset
+- Initial load execution for all five datasets (TTC subway, bus, streetcar, Bike Share, weather) spanning 2019-present
+- Row count validation: `SELECT COUNT(*)` on each RAW table compared against source file row counts with 1% tolerance
+- Snowflake Python connector (`snowflake-connector-python`) integration with LOADER_ROLE credentials
+- Unit and integration tests via `pytest`
+- Type-annotated modules passing `mypy --strict`
+- Linting compliance with `ruff check` and `ruff format`
+
+### Out of Scope
+
+- Snowflake object creation (database, schemas, warehouses, roles — completed in PH-02)
+- dbt transformations (staging, intermediate, marts — covered by PH-05, PH-06, PH-07)
+- Incremental loading strategies (full reload is acceptable for v1 data volumes per DESIGN-DOC.md Decision D8)
+- Orchestration scheduling (Airflow/Dagster — explicitly out of scope per DESIGN-DOC.md Non-Goal NG4)
+- Data quality validation beyond row counts (covered by PH-08)
+
+## Technical Approach
+
+### Architecture Decisions
+
+- **Internal stage over external stage**: Use a Snowflake internal named stage (`@RAW.INGESTION_STAGE`) rather than an S3/GCS external stage. Internal stages eliminate cloud storage dependencies, simplify credential management for a portfolio project, and provide sufficient throughput for the 2-3 GB total data volume. Per DESIGN-DOC.md Section 5.1, the pipeline is batch-only.
+- **`COPY INTO` with `MERGE` for idempotency**: Execute `COPY INTO` to a temporary table, then `MERGE` from temporary to target using natural keys. This prevents duplicate rows on repeated runs. Natural keys are defined in DESIGN-DOC.md Section 6.4: TTC subway uses `[date, time, station, line, delay_code, min_delay]`; Bike Share uses `[trip_id]`; weather uses `[date]`.
+- **Per-dataset atomic transactions**: Each dataset loads within a single Snowflake transaction. If any `COPY INTO` or `MERGE` fails, the transaction rolls back and no rows from that dataset persist. Cross-dataset atomicity is not required — partial completion (e.g., subway loaded, bus failed) is acceptable since datasets are independent.
+- **`snowflake-connector-python` over SQLAlchemy**: Use the native Snowflake connector directly for `PUT`, `COPY INTO`, and `MERGE` operations. SQLAlchemy adds unnecessary abstraction for bulk loading operations and does not support `PUT` commands natively.
+- **LOADER_ROLE for all load operations**: Per DESIGN-DOC.md Section 10.1, the `LOADER_ROLE` owns RAW schema objects. All Snowflake connections in `load.py` authenticate as `LOADER_SVC` with `LOADER_ROLE`.
+
+### Integration Points
+
+- Upstream: Reads validated CSV files from `data/validated/<source>/<year>/` produced by E-302
+- Snowflake: Connects to `TORONTO_MOBILITY.RAW` schema via `snowflake-connector-python` using `LOADER_ROLE` credentials
+- Snowflake internal stage: `@TORONTO_MOBILITY.RAW.INGESTION_STAGE`
+- Target RAW tables: `TTC_SUBWAY_DELAYS`, `TTC_BUS_DELAYS`, `TTC_STREETCAR_DELAYS`, `BIKE_SHARE_TRIPS`, `WEATHER_DAILY` (per DESIGN-DOC.md Section 5.3)
+- Credential source: Environment variables (`SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PASSWORD`) or `~/.snowflake/connections.toml`
+
+### Repository Areas
+
+- `scripts/load.py` — Snowflake loading module
+- `scripts/ingest.py` — top-level pipeline orchestrator
+- `tests/test_load.py` — loading test suite
+- `tests/test_ingest.py` — orchestration test suite
+- `pyproject.toml` — dependency declaration (`snowflake-connector-python`)
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Snowflake trial credentials expire during initial load execution | Low | High | Verify trial expiration date before starting; complete initial load within a single session; store credentials in environment variables, not code |
+| `PUT` upload of large Bike Share CSV files (500MB+) times out or fails mid-transfer | Medium | Medium | Upload files in per-year batches rather than all at once; implement retry logic on `PUT` failures with exponential backoff |
+| `MERGE` natural key collisions produce incorrect deduplication for TTC delays with identical timestamp/station/code combinations | Medium | High | Natural key includes `min_delay` to disambiguate per DESIGN-DOC.md Section 6.4; add post-load row count validation to detect unexpected deduplication |
+| Row count tolerance check fails due to filtered rows (Bike Share trips < 60 seconds) | Low | Medium | Apply the same 60-second filter to source file row counts before comparison; document the filter in validation output |
+| Snowflake LOADER_ROLE lacks required permissions on internal stage | Low | Medium | Verify grants include `CREATE STAGE` and `USAGE` on RAW schema before first load; document grant verification in S001 |
+
+## Stories
+
+| ID | Story | Points | Dependencies | Status |
+| --- | --- | --- | --- | --- |
+| S001 | Create Snowflake internal stage and verify LOADER_ROLE permissions | 2 | None | Draft |
+| S002 | Implement Snowflake connection manager with credential resolution | 3 | None | Draft |
+| S003 | Implement CSV upload via PUT and COPY INTO bulk loading | 5 | S001, S002 | Draft |
+| S004 | Implement MERGE-based idempotent upsert with natural keys | 5 | S003 | Draft |
+| S005 | Build pipeline orchestrator with atomic transaction control | 5 | S003, S004, E-301.S002, E-302.S003 | Draft |
+| S006 | Execute initial load and validate row counts for all datasets | 5 | S005 | Draft |
+| S007 | Add comprehensive test suite for loading and orchestration | 5 | S003, S004, S005 | Draft |
+
+---
+
+### S001: Create Snowflake internal stage and verify LOADER_ROLE permissions
+
+**Description**: Create the named internal stage in Snowflake RAW schema and verify that LOADER_ROLE has all required permissions for PUT, COPY INTO, and MERGE operations.
+
+**Acceptance Criteria**:
+
+- [ ] SQL script `setup/create_ingestion_stage.sql` exists and creates stage: `CREATE STAGE IF NOT EXISTS TORONTO_MOBILITY.RAW.INGESTION_STAGE FILE_FORMAT = (TYPE = 'CSV' FIELD_OPTIONALLY_ENCLOSED_BY = '"' SKIP_HEADER = 1 NULL_IF = ('', 'NULL', 'null') COMPRESSION = 'AUTO')`
+- [ ] Stage file format specifies: `FIELD_DELIMITER = ','`, `RECORD_DELIMITER = '\n'`, `ENCODING = 'UTF8'`
+- [ ] Script grants `USAGE` on the stage to `LOADER_ROLE`: `GRANT USAGE ON STAGE TORONTO_MOBILITY.RAW.INGESTION_STAGE TO ROLE LOADER_ROLE`
+- [ ] Verification query confirms LOADER_ROLE can execute `LIST @TORONTO_MOBILITY.RAW.INGESTION_STAGE` without permission errors
+- [ ] Verification query confirms LOADER_ROLE can execute `PUT` to the stage (upload a 1-row test CSV, then `REMOVE` it)
+- [ ] Verification query confirms all five RAW tables exist: `TTC_SUBWAY_DELAYS`, `TTC_BUS_DELAYS`, `TTC_STREETCAR_DELAYS`, `BIKE_SHARE_TRIPS`, `WEATHER_DAILY`
+
+**Technical Notes**: Execute this script via `snowsql` or the Snowflake web UI using SYSADMIN role. The file format definition is embedded in the stage to avoid separate file format object management. `FIELD_OPTIONALLY_ENCLOSED_BY` handles quoted fields in CSV exports.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S002: Implement Snowflake connection manager with credential resolution
+
+**Description**: Build a connection manager that resolves Snowflake credentials from environment variables or configuration file and returns authenticated cursor objects scoped to LOADER_ROLE.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/load.py` defines class `SnowflakeConnectionManager` with method `connect() -> snowflake.connector.SnowflakeConnection`
+- [ ] Credential resolution order: (1) environment variables `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PASSWORD`, (2) `~/.snowflake/connections.toml` file with `[loader]` section
+- [ ] Connection parameters include: `role='LOADER_ROLE'`, `warehouse='TRANSFORM_WH'`, `database='TORONTO_MOBILITY'`, `schema='RAW'`
+- [ ] Context manager protocol (`__enter__` / `__exit__`) is implemented, ensuring `connection.close()` on exit
+- [ ] On connection failure, raises `LoadError` with the Snowflake error code and message (credential values are never included in the error message)
+- [ ] `mypy --strict scripts/load.py` passes with zero errors
+- [ ] `ruff check scripts/load.py && ruff format --check scripts/load.py` passes
+
+**Technical Notes**: Use `snowflake.connector.connect()` directly. Do not use SQLAlchemy. Set `client_session_keep_alive=True` to prevent session timeout during long upload operations. Set `login_timeout=30` and `network_timeout=60`.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S003: Implement CSV upload via PUT and COPY INTO bulk loading
+
+**Description**: Build functions that upload validated CSV files to the Snowflake internal stage via PUT and execute COPY INTO to load data into RAW tables.
+
+**Acceptance Criteria**:
+
+- [ ] Function `upload_to_stage(connection: SnowflakeConnection, local_path: Path, stage_path: str) -> StageUploadResult` exists in `scripts/load.py`
+- [ ] `StageUploadResult` dataclass contains: `local_path`, `stage_path`, `status` (enum: `UPLOADED`, `SKIPPED`), `source_size_bytes`, `dest_size_bytes`, `elapsed_seconds`
+- [ ] Function executes `PUT file://<local_path> @TORONTO_MOBILITY.RAW.INGESTION_STAGE/<stage_path> AUTO_COMPRESS=TRUE OVERWRITE=TRUE`
+- [ ] Function `copy_into_table(connection: SnowflakeConnection, table_name: str, stage_path: str, column_mapping: list[str]) -> CopyResult` exists in `scripts/load.py`
+- [ ] `CopyResult` dataclass contains: `table_name`, `rows_loaded`, `rows_parsed`, `errors_seen`, `first_error` (str or None), `elapsed_seconds`
+- [ ] COPY INTO statement uses: `ON_ERROR = 'ABORT_STATEMENT'` to fail on first row-level error
+- [ ] COPY INTO statement uses: `PURGE = FALSE` to retain staged files for debugging
+- [ ] Function `copy_into_table` accepts a `column_mapping` parameter to handle column ordering differences between CSV headers and target table DDL
+- [ ] On COPY INTO failure, function raises `LoadError` with the table name, file path, row number, and error message from Snowflake
+- [ ] `mypy --strict scripts/load.py` passes with zero errors
+
+**Technical Notes**: The `PUT` command is executed via cursor's `execute()` method. Use `cursor.fetchall()` after PUT to retrieve upload status. COPY INTO uses the stage file format defined in S001. For column mapping, use `COPY INTO ... (col1, col2, ...) FROM (SELECT $1, $2, ... FROM @stage/path)` syntax when CSV column order differs from table DDL.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S004: Implement MERGE-based idempotent upsert with natural keys
+
+**Description**: Build the MERGE logic that upserts data from a staging temporary table into the target RAW table using natural keys, ensuring repeated loads produce identical results.
+
+**Acceptance Criteria**:
+
+- [ ] Function `merge_into_table(connection: SnowflakeConnection, target_table: str, natural_keys: list[str], all_columns: list[str]) -> MergeResult` exists in `scripts/load.py`
+- [ ] `MergeResult` dataclass contains: `target_table`, `rows_inserted`, `rows_updated`, `elapsed_seconds`
+- [ ] Function creates a temporary table `{target_table}_STAGING` with identical DDL to the target table
+- [ ] Function executes COPY INTO the temporary table first, then MERGE from temporary to target
+- [ ] MERGE ON clause joins on all columns specified in `natural_keys`
+- [ ] WHEN MATCHED clause updates all non-key columns
+- [ ] WHEN NOT MATCHED clause inserts all columns
+- [ ] Function drops the temporary table after MERGE completes (in both success and failure paths)
+- [ ] Natural key definitions per dataset match DESIGN-DOC.md Section 6.4: TTC subway `[DATE, TIME, STATION, LINE, CODE, MIN_DELAY]`, TTC bus `[DATE, TIME, ROUTE, DIRECTION, DELAY_CODE, MIN_DELAY]`, TTC streetcar `[DATE, TIME, ROUTE, DIRECTION, DELAY_CODE, MIN_DELAY]`, Bike Share `[TRIP_ID]`, weather `[DATE_TIME]`
+- [ ] Running the same load twice produces identical row counts in the target table (verified by test)
+- [ ] `mypy --strict scripts/load.py` passes with zero errors
+
+**Technical Notes**: Use `CREATE TEMPORARY TABLE {target}_STAGING LIKE {target}` for DDL cloning. The temporary table is session-scoped and auto-drops on connection close, but explicit `DROP` in a `finally` block ensures cleanup on exceptions. For the MERGE statement, dynamically construct the SQL from the `natural_keys` and `all_columns` parameters using parameterized f-strings (column names only, no user input — SQL injection is not a concern for internal column names).
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S005: Build pipeline orchestrator with atomic transaction control
+
+**Description**: Build the top-level `ingest.py` script that sequences download, transform, validate, and load stages with per-dataset atomic transaction boundaries.
+
+**Acceptance Criteria**:
+
+- [ ] File `scripts/ingest.py` exists and defines function `run_pipeline(datasets: list[str] | None = None, skip_download: bool = False) -> PipelineResult`
+- [ ] `PipelineResult` dataclass contains: `datasets_processed` (list of `DatasetResult`), `total_rows_loaded`, `total_elapsed_seconds`, `success` (bool)
+- [ ] `DatasetResult` dataclass contains: `dataset_name`, `stage` (enum: `DOWNLOAD`, `TRANSFORM`, `VALIDATE`, `LOAD`), `rows_loaded`, `elapsed_seconds`, `status` (enum: `SUCCESS`, `FAILED`, `SKIPPED`)
+- [ ] Pipeline sequence per dataset: (1) download via E-301 `download.py`, (2) transform XLSX→CSV via E-302 `transform.py`, (3) validate against schema contract via E-302 `validate.py`, (4) load into Snowflake via `load.py`
+- [ ] Each dataset's load stage executes within a single Snowflake transaction: `connection.cursor().execute("BEGIN")` before COPY INTO / MERGE, `connection.commit()` on success, `connection.rollback()` on any exception
+- [ ] If validation fails for a dataset (E-302 `SchemaValidationError`), that dataset is marked `FAILED` and subsequent datasets continue processing (fail-per-dataset, not fail-all)
+- [ ] If load fails for a dataset (`LoadError`), the transaction rolls back, the dataset is marked `FAILED`, and subsequent datasets continue processing
+- [ ] CLI entry point: `python scripts/ingest.py --all` runs all datasets; `python scripts/ingest.py --dataset ttc_subway_delays` runs a single dataset; `python scripts/ingest.py --all --skip-download` skips the download stage (for re-processing already-downloaded files)
+- [ ] Pipeline exits with code 0 if all datasets succeed, code 1 if any dataset fails
+- [ ] Execution summary is logged to stdout as structured output: dataset name, stage, status, rows, elapsed time
+- [ ] `mypy --strict scripts/ingest.py` passes with zero errors
+- [ ] `ruff check scripts/ingest.py && ruff format --check scripts/ingest.py` passes
+
+**Technical Notes**: Use `argparse` for CLI parsing. Import functions from `download.py`, `transform.py`, `validate.py`, and `load.py` — do not duplicate logic. Wrap each dataset in a `try`/`except` block that catches `DownloadError`, `TransformError`, `SchemaValidationError`, and `LoadError`. Log to stderr for progress, stdout for final summary.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S006: Execute initial load and validate row counts for all datasets
+
+**Description**: Run the full ingestion pipeline against production data for 2019-present, load all five datasets into the Snowflake RAW schema, and validate row counts against source files within 1% tolerance.
+
+**Acceptance Criteria**:
+
+- [ ] Running `python scripts/ingest.py --all` completes with exit code 0 for all five datasets
+- [ ] Snowflake table `TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS` contains rows and `SELECT COUNT(*)` matches source file row count within 1% tolerance (expected ~300K rows per DESIGN-DOC.md Section 4.1)
+- [ ] Snowflake table `TORONTO_MOBILITY.RAW.TTC_BUS_DELAYS` contains rows and count matches source within 1% (expected ~1.2M rows)
+- [ ] Snowflake table `TORONTO_MOBILITY.RAW.TTC_STREETCAR_DELAYS` contains rows and count matches source within 1% (expected ~300K rows)
+- [ ] Snowflake table `TORONTO_MOBILITY.RAW.BIKE_SHARE_TRIPS` contains rows and count matches source within 1% (expected ~30M rows)
+- [ ] Snowflake table `TORONTO_MOBILITY.RAW.WEATHER_DAILY` contains rows and count matches source within 1% (expected ~2,500 rows for 2019-2025)
+- [ ] Row count validation script `scripts/validate_load.py` exists and executes: reads source file row counts from the download manifest, queries `SELECT COUNT(*)` from each RAW table, computes percentage difference, passes if all datasets are within 1%
+- [ ] Running `python scripts/validate_load.py` exits with code 0 and prints a comparison table: dataset name, source rows, loaded rows, difference percentage
+- [ ] Re-running `python scripts/ingest.py --all` produces identical row counts (idempotency verified via MERGE)
+- [ ] `mypy --strict scripts/validate_load.py` passes with zero errors
+
+**Technical Notes**: The 1% tolerance accounts for edge cases: Bike Share files occasionally contain duplicate trip IDs across quarterly files (MERGE deduplicates these), and Environment Canada CSVs sometimes include partial-month data at file boundaries. The validation script connects using LOADER_ROLE credentials. Log per-table results in a formatted table to stdout.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+### S007: Add comprehensive test suite for loading and orchestration
+
+**Description**: Build pytest test suites covering the Snowflake loading module and pipeline orchestrator with mocked Snowflake connections.
+
+**Acceptance Criteria**:
+
+- [ ] File `tests/test_load.py` exists with tests covering: connection manager credential resolution from environment variables, connection manager context manager closes connection on exit, `upload_to_stage` constructs correct PUT SQL, `copy_into_table` constructs correct COPY INTO SQL with ON_ERROR=ABORT_STATEMENT, `merge_into_table` constructs correct MERGE SQL with natural keys, `merge_into_table` drops temporary table in finally block, `LoadError` is raised on Snowflake error response
+- [ ] File `tests/test_ingest.py` exists with tests covering: successful pipeline run returns PipelineResult with SUCCESS status, validation failure for one dataset does not block other datasets, load failure triggers transaction rollback, `--skip-download` flag skips download stage, CLI exits with code 1 when any dataset fails
+- [ ] All Snowflake interactions are mocked using `unittest.mock.patch` on `snowflake.connector.connect` — no real Snowflake connections during test execution
+- [ ] Tests verify SQL statements passed to `cursor.execute()` contain expected keywords (`PUT`, `COPY INTO`, `MERGE`, `BEGIN`, `COMMIT`, `ROLLBACK`)
+- [ ] `pytest tests/test_load.py tests/test_ingest.py -v` passes with zero failures
+- [ ] `mypy --strict tests/test_load.py tests/test_ingest.py` passes
+- [ ] `ruff check tests/ && ruff format --check tests/` passes on test files
+
+**Technical Notes**: Mock the Snowflake connector at the module level: `@patch('scripts.load.snowflake.connector.connect')`. Create mock cursor objects that return predefined results for `fetchall()` and `fetchone()`. For MERGE tests, verify the SQL contains both `WHEN MATCHED THEN UPDATE` and `WHEN NOT MATCHED THEN INSERT` clauses.
+
+**Definition of Done**:
+
+- [ ] Code committed to feature branch
+- [ ] Tests pass locally
+- [ ] PR opened with linked issue
+- [ ] CI checks green
+
+---
+
+## Exit Criteria
+
+This epic is complete when:
+
+- [ ] `scripts/load.py` and `scripts/ingest.py` exist, are type-annotated, and pass `mypy --strict`
+- [ ] Snowflake internal stage `@TORONTO_MOBILITY.RAW.INGESTION_STAGE` exists with correct file format and LOADER_ROLE permissions
+- [ ] All five RAW schema tables are populated with 2019-present data
+- [ ] Row counts for each table match source file counts within 1% tolerance
+- [ ] MERGE-based loading is idempotent: re-running produces identical row counts
+- [ ] Per-dataset atomic transactions prevent partial loads on failure
+- [ ] `pytest tests/test_load.py tests/test_ingest.py` passes with zero failures
+- [ ] `ruff check` and `ruff format` pass on all Python files in `scripts/` and `tests/`
+- [ ] Python code generated via `python-writing` skill
+- [ ] PH-03 exit criterion met: RAW schema tables populated with row counts validated against source files within 1% tolerance


### PR DESCRIPTION
## Summary

- Add three implementation-ready epics decomposing Phase 03 (Data Ingestion Pipeline) into actionable work items
- **E-301**: Data Download & Source Acquisition — `download.py`, CKAN API integration, Environment Canada weather fetch, download manifest with idempotency (6 stories, 22 points)
- **E-302**: Schema Validation & Data Transformation — `validate.py` with fail-fast enforcement per DESIGN-DOC.md Section 4.3, `transform.py` for XLSX→CSV, encoding normalization (6 stories, 26 points)
- **E-303**: Snowflake Loading & Pipeline Orchestration — `load.py` with COPY INTO/MERGE idempotency, `ingest.py` atomic orchestrator, initial load execution, row count validation within 1% tolerance (7 stories, 30 points)

Total: **19 stories, 78 story points** across 3 sequentially dependent epics.

Closes #16

## Change Type

- [x] `docs` — Documentation changes

## Design Impact

- **Architecture Layer**: None (planning artifacts only)
- **Schema Changes**: None

## Testing Evidence

- All three epic files pass structural validation: required sections present, story counts within 3-8 range, story points within 15-40 per epic, zero forbidden patterns
- Epic IDs (E-301, E-302, E-303) are unique across repository (no conflict with existing E-201, E-202, E-203)
- Pre-commit hooks pass: Protocol Zero codebase scan, commit message validation, gitleaks secret scan

## Risk Assessment

- **Risk Level**: Low
- **Rollback Plan**: Revert commit; no code or infrastructure changes

## Governance Checklist

- [x] Epics generated via `epic-writer` skill
- [x] Epic files saved to `docs/PH-03/`
- [x] All stories have testable acceptance criteria
- [x] No AI-attribution breadcrumbs in content
- [x] Commit message follows Conventional Commits standard
- [x] File naming follows `<topic>_<epic_id>.md` convention