### PR TITLE
feat(scripts): add Snowflake loading and pipeline orchestration (E-303)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "charset-normalizer>=3.3.0,<4.0.0",
     "httpx>=0.27.0,<1.0.0",
     "openpyxl>=3.1.0,<4.0.0",
+    "snowflake-connector-python>=3.12.0,<4.0.0",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +42,14 @@ exclude = [
 module = "tests.*"
 disallow_untyped_defs = false
 disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+module = "snowflake.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "openpyxl.*"
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py312"

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,0 +1,418 @@
+"""Pipeline orchestrator for Toronto Urban Mobility data ingestion.
+
+Sequences download, transform, validate, and Snowflake load stages
+with per-dataset atomic transaction boundaries. Each dataset processes
+independently: a failure in one dataset does not block others.
+
+Usage:
+    python scripts/ingest.py --all
+    python scripts/ingest.py --dataset ttc_subway_delays
+    python scripts/ingest.py --all --skip-download
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+import snowflake.connector
+
+from scripts.config import DATASETS, get_dataset_by_name
+from scripts.contracts import CONTRACTS
+from scripts.download import DownloadError, download_dataset
+from scripts.download import DownloadManifest as _DownloadManifest
+from scripts.load import (
+    DatasetStatus,
+    LoadError,
+    MergeResult,
+    PipelineStage,
+    SnowflakeConnectionManager,
+    get_table_config,
+    load_dataset,
+)
+from scripts.validate import SchemaValidationError
+
+logger: Final[logging.Logger] = logging.getLogger(__name__)
+
+_RAW_DIR: Final[Path] = Path("data/raw")
+_VALIDATED_DIR: Final[Path] = Path("data/validated")
+
+
+# ---- Result dataclasses -----------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetResult:
+    """Outcome of processing a single dataset through the pipeline.
+
+    Attributes:
+        dataset_name: Machine-readable dataset identifier.
+        stage: Last pipeline stage attempted.
+        rows_loaded: Number of rows loaded into Snowflake.
+        elapsed_seconds: Wall-clock time for the full dataset.
+        status: Final outcome status.
+        error_message: Description of failure, if any.
+    """
+
+    dataset_name: str
+    stage: PipelineStage
+    rows_loaded: int
+    elapsed_seconds: float
+    status: DatasetStatus
+    error_message: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineResult:
+    """Aggregate outcome of a full pipeline execution.
+
+    Attributes:
+        datasets_processed: Per-dataset results.
+        total_rows_loaded: Sum of rows loaded across all datasets.
+        total_elapsed_seconds: Wall-clock time for the full pipeline.
+        success: True only if every dataset succeeded.
+    """
+
+    datasets_processed: list[DatasetResult] = field(default_factory=list)
+    total_rows_loaded: int = 0
+    total_elapsed_seconds: float = 0.0
+    success: bool = True
+
+
+# ---- Dataset subdirectory mapping -------------------------------------------
+
+
+_DATASET_SUBDIRS: Final[dict[str, str]] = {
+    "ttc_subway_delays": "ttc_subway",
+    "ttc_bus_delays": "ttc_bus",
+    "ttc_streetcar_delays": "ttc_streetcar",
+    "bike_share_ridership": "bike_share",
+    "weather_daily": "weather",
+}
+
+
+def _get_validated_csvs(dataset_name: str) -> list[Path]:
+    """Collect all validated CSV files for a dataset.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+
+    Returns:
+        Sorted list of CSV file paths under data/validated/.
+    """
+    subdir = _DATASET_SUBDIRS.get(dataset_name, "")
+    validated_dir = _VALIDATED_DIR / subdir
+    if not validated_dir.exists():
+        return []
+    return sorted(validated_dir.rglob("*.csv"))
+
+
+# ---- Stage executors ---------------------------------------------------------
+
+
+def _run_download(dataset_name: str) -> None:
+    """Execute the download stage for a single dataset."""
+    config = get_dataset_by_name(dataset_name)
+    manifest_path = _RAW_DIR / ".manifest.json"
+    manifest = _DownloadManifest.load(manifest_path)
+    manifest.prune()
+    download_dataset(config, _RAW_DIR, manifest)
+
+
+def _run_transform_and_validate(dataset_name: str) -> None:
+    """Execute transform and validate stages for a single dataset.
+
+    Imports the validation pipeline runner which handles XLSX conversion,
+    encoding normalization, column renaming, and schema validation.
+    """
+    from scripts.validate import _run_pipeline as validate_pipeline
+
+    contract = CONTRACTS[dataset_name]
+    validate_pipeline(
+        dataset_name=dataset_name,
+        contract=contract,
+        source_dir=_RAW_DIR,
+        output_dir=_VALIDATED_DIR,
+    )
+
+
+def _run_load(
+    dataset_name: str,
+    connection_manager: SnowflakeConnectionManager,
+) -> MergeResult:
+    """Execute the Snowflake load stage with atomic transaction control.
+
+    Opens a dedicated connection, begins a transaction, loads all CSV
+    files via PUT + MERGE, and commits on success or rolls back on
+    failure.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+        connection_manager: Pre-configured connection manager.
+
+    Returns:
+        MergeResult from the load operation.
+
+    Raises:
+        LoadError: If any load operation fails (transaction rolled back).
+    """
+    csv_files = _get_validated_csvs(dataset_name)
+    if not csv_files:
+        raise LoadError(
+            f"No validated CSV files found for {dataset_name}",
+            table=get_table_config(dataset_name).table_name,
+        )
+
+    with connection_manager as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute("BEGIN")
+            result = load_dataset(conn, dataset_name, csv_files)
+            conn.commit()
+            return result
+        except (LoadError, snowflake.connector.errors.Error):
+            conn.rollback()
+            raise
+        finally:
+            cursor.close()
+
+
+# ---- Pipeline orchestration --------------------------------------------------
+
+
+def run_pipeline(
+    datasets: list[str] | None = None,
+    skip_download: bool = False,
+) -> PipelineResult:
+    """Execute the ingestion pipeline for specified datasets.
+
+    Processes each dataset independently through four stages:
+    download, transform, validate, and load. Per-dataset failures
+    are captured without blocking subsequent datasets.
+
+    Args:
+        datasets: Specific datasets to process. None processes all.
+        skip_download: Skip the download stage (re-process existing files).
+
+    Returns:
+        PipelineResult with per-dataset outcomes and aggregate metrics.
+    """
+    pipeline_start = time.monotonic()
+    dataset_names = datasets or [d.name for d in DATASETS]
+    connection_manager = SnowflakeConnectionManager()
+
+    results: list[DatasetResult] = []
+    all_success = True
+
+    for name in dataset_names:
+        dataset_start = time.monotonic()
+        logger.info("Processing dataset: %s", name)
+
+        try:
+            _process_single_dataset(
+                name,
+                connection_manager,
+                skip_download,
+            )
+        except DownloadError as exc:
+            elapsed = time.monotonic() - dataset_start
+            results.append(
+                DatasetResult(
+                    dataset_name=name,
+                    stage=PipelineStage.DOWNLOAD,
+                    rows_loaded=0,
+                    elapsed_seconds=round(elapsed, 3),
+                    status=DatasetStatus.FAILED,
+                    error_message=str(exc),
+                )
+            )
+            all_success = False
+            logger.error("FAILED [%s] download: %s", name, exc)
+            continue
+        except SchemaValidationError as exc:
+            elapsed = time.monotonic() - dataset_start
+            results.append(
+                DatasetResult(
+                    dataset_name=name,
+                    stage=PipelineStage.VALIDATE,
+                    rows_loaded=0,
+                    elapsed_seconds=round(elapsed, 3),
+                    status=DatasetStatus.FAILED,
+                    error_message=str(exc),
+                )
+            )
+            all_success = False
+            logger.error("FAILED [%s] validation: %s", name, exc)
+            continue
+        except LoadError as exc:
+            elapsed = time.monotonic() - dataset_start
+            results.append(
+                DatasetResult(
+                    dataset_name=name,
+                    stage=PipelineStage.LOAD,
+                    rows_loaded=0,
+                    elapsed_seconds=round(elapsed, 3),
+                    status=DatasetStatus.FAILED,
+                    error_message=str(exc),
+                )
+            )
+            all_success = False
+            logger.error("FAILED [%s] load: %s", name, exc)
+            continue
+
+        elapsed = time.monotonic() - dataset_start
+        csv_count = len(_get_validated_csvs(name))
+        results.append(
+            DatasetResult(
+                dataset_name=name,
+                stage=PipelineStage.LOAD,
+                rows_loaded=csv_count,
+                elapsed_seconds=round(elapsed, 3),
+                status=DatasetStatus.SUCCESS,
+            )
+        )
+        logger.info("SUCCESS [%s] in %.1fs", name, elapsed)
+
+    total_rows = sum(r.rows_loaded for r in results)
+    pipeline_elapsed = time.monotonic() - pipeline_start
+
+    return PipelineResult(
+        datasets_processed=results,
+        total_rows_loaded=total_rows,
+        total_elapsed_seconds=round(pipeline_elapsed, 3),
+        success=all_success,
+    )
+
+
+def _process_single_dataset(
+    dataset_name: str,
+    connection_manager: SnowflakeConnectionManager,
+    skip_download: bool,
+) -> None:
+    """Run all pipeline stages for a single dataset.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+        connection_manager: Pre-configured connection manager.
+        skip_download: Skip the download stage.
+
+    Raises:
+        DownloadError: If download fails.
+        SchemaValidationError: If validation fails.
+        LoadError: If Snowflake load fails.
+    """
+    if not skip_download:
+        logger.info("[%s] Stage: DOWNLOAD", dataset_name)
+        _run_download(dataset_name)
+
+    logger.info("[%s] Stage: TRANSFORM + VALIDATE", dataset_name)
+    _run_transform_and_validate(dataset_name)
+
+    logger.info("[%s] Stage: LOAD", dataset_name)
+    _run_load(dataset_name, connection_manager)
+
+
+# ---- CLI ---------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ingestion pipeline CLI."""
+    parser = argparse.ArgumentParser(
+        description="Toronto Mobility data ingestion pipeline.",
+    )
+    parser.add_argument(
+        "--all",
+        dest="run_all",
+        action="store_true",
+        help="Process all five datasets.",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="Process a single dataset by name.",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Skip download stage; re-process already-downloaded files.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug-level logging.",
+    )
+    return parser
+
+
+def _print_summary(result: PipelineResult) -> None:
+    """Print structured execution summary to stdout."""
+    header = f"{'Dataset':<30} {'Stage':<12} {'Status':<10} {'Rows':<10} {'Time (s)'}"
+    print(f"\n{'=' * 80}")
+    print("Pipeline Execution Summary")
+    print(f"{'=' * 80}")
+    print(header)
+    print("-" * 80)
+
+    for ds in result.datasets_processed:
+        print(
+            f"{ds.dataset_name:<30} "
+            f"{ds.stage.value:<12} "
+            f"{ds.status.value:<10} "
+            f"{ds.rows_loaded:<10} "
+            f"{ds.elapsed_seconds:.1f}"
+        )
+
+    print("-" * 80)
+    print(
+        f"Total rows: {result.total_rows_loaded}  "
+        f"Elapsed: {result.total_elapsed_seconds:.1f}s  "
+        f"Result: {'SUCCESS' if result.success else 'FAILED'}"
+    )
+    print(f"{'=' * 80}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the ingestion pipeline.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code: 0 if all datasets succeed, 1 if any fail.
+    """
+    parser = _build_arg_parser()
+    args: argparse.Namespace = parser.parse_args(argv)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    if not args.run_all and args.dataset is None:
+        parser.error("Specify --all or --dataset <name>")
+        return 1
+
+    dataset_list: list[str] | None = None
+    if args.dataset is not None:
+        dataset_list = [args.dataset]
+
+    result = run_pipeline(
+        datasets=dataset_list,
+        skip_download=args.skip_download,
+    )
+
+    _print_summary(result)
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load.py
+++ b/scripts/load.py
@@ -1,0 +1,783 @@
+"""Snowflake loading module for Toronto Urban Mobility Analytics.
+
+Manages authenticated connections to Snowflake via LOADER_ROLE,
+uploads validated CSV files to an internal stage via PUT, executes
+bulk COPY INTO for raw ingestion, and performs MERGE-based idempotent
+upserts using natural keys defined in DESIGN-DOC.md Section 6.4.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+import snowflake.connector
+
+if TYPE_CHECKING:
+    from snowflake.connector import SnowflakeConnection
+
+logger: Final[logging.Logger] = logging.getLogger(__name__)
+
+# ---- Snowflake connection defaults (DESIGN-DOC.md Section 10) ---------------
+
+_DEFAULT_ROLE: Final[str] = "LOADER_ROLE"
+_DEFAULT_WAREHOUSE: Final[str] = "TRANSFORM_WH"
+_DEFAULT_DATABASE: Final[str] = "TORONTO_MOBILITY"
+_DEFAULT_SCHEMA: Final[str] = "RAW"
+_STAGE_PATH: Final[str] = "@TORONTO_MOBILITY.RAW.INGESTION_STAGE"
+
+_LOGIN_TIMEOUT: Final[int] = 30
+_NETWORK_TIMEOUT: Final[int] = 60
+
+
+# ---- Exceptions -------------------------------------------------------------
+
+
+class LoadError(Exception):
+    """Raised when a Snowflake loading operation fails.
+
+    Attributes:
+        table: Target table name, if applicable.
+        file_path: Source file path, if applicable.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        table: str = "",
+        file_path: str = "",
+    ) -> None:
+        self.table: Final[str] = table
+        self.file_path: Final[str] = file_path
+        super().__init__(message)
+
+
+# ---- Enums ------------------------------------------------------------------
+
+
+class StageUploadStatus(enum.Enum):
+    """Result status of a PUT upload operation."""
+
+    UPLOADED = "UPLOADED"
+    SKIPPED = "SKIPPED"
+
+
+class PipelineStage(enum.Enum):
+    """Pipeline execution stage identifier."""
+
+    DOWNLOAD = "DOWNLOAD"
+    TRANSFORM = "TRANSFORM"
+    VALIDATE = "VALIDATE"
+    LOAD = "LOAD"
+
+
+class DatasetStatus(enum.Enum):
+    """Outcome status for a single dataset in the pipeline."""
+
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
+
+
+# ---- Result dataclasses -----------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class StageUploadResult:
+    """Outcome of uploading a single file to the Snowflake internal stage.
+
+    Attributes:
+        local_path: Absolute path to the uploaded file on disk.
+        stage_path: Relative path within the internal stage.
+        status: Whether the file was uploaded or skipped.
+        source_size_bytes: File size on disk before compression.
+        dest_size_bytes: Compressed size reported by Snowflake.
+        elapsed_seconds: Wall-clock time for the PUT operation.
+    """
+
+    local_path: Path
+    stage_path: str
+    status: StageUploadStatus
+    source_size_bytes: int
+    dest_size_bytes: int
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class CopyResult:
+    """Outcome of a COPY INTO operation from stage to table.
+
+    Attributes:
+        table_name: Fully-qualified target table.
+        rows_loaded: Number of rows successfully loaded.
+        rows_parsed: Number of rows parsed from staged files.
+        errors_seen: Number of row-level errors encountered.
+        first_error: Description of the first error, if any.
+        elapsed_seconds: Wall-clock time for the COPY INTO.
+    """
+
+    table_name: str
+    rows_loaded: int
+    rows_parsed: int
+    errors_seen: int
+    first_error: str | None
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class MergeResult:
+    """Outcome of a MERGE upsert operation.
+
+    Attributes:
+        target_table: Fully-qualified target table.
+        rows_inserted: Rows inserted (NOT MATCHED clause).
+        rows_updated: Rows updated (MATCHED clause).
+        elapsed_seconds: Wall-clock time for the full MERGE cycle.
+    """
+
+    target_table: str
+    rows_inserted: int
+    rows_updated: int
+    elapsed_seconds: float
+
+
+# ---- Table configuration registry -------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TableConfig:
+    """Mapping between a source dataset and its Snowflake RAW table.
+
+    Attributes:
+        table_name: Fully-qualified Snowflake table name.
+        columns: Snowflake column names in CSV positional order.
+        natural_keys: Columns forming the natural key for MERGE dedup.
+        stage_prefix: Subdirectory within the internal stage.
+    """
+
+    table_name: str
+    columns: tuple[str, ...]
+    natural_keys: tuple[str, ...]
+    stage_prefix: str
+
+
+TABLE_CONFIGS: Final[dict[str, TableConfig]] = {
+    "ttc_subway_delays": TableConfig(
+        table_name="TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+        columns=(
+            "DATE",
+            "TIME",
+            "DAY",
+            "STATION",
+            "CODE",
+            "MIN_DELAY",
+            "MIN_GAP",
+            "BOUND",
+            "LINE",
+        ),
+        natural_keys=("DATE", "TIME", "STATION", "LINE", "CODE", "MIN_DELAY"),
+        stage_prefix="ttc_subway",
+    ),
+    "ttc_bus_delays": TableConfig(
+        table_name="TORONTO_MOBILITY.RAW.TTC_BUS_DELAYS",
+        columns=(
+            "DATE",
+            "ROUTE",
+            "TIME",
+            "DAY",
+            "LOCATION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+            "MIN_GAP",
+            "DIRECTION",
+        ),
+        natural_keys=(
+            "DATE",
+            "TIME",
+            "ROUTE",
+            "DIRECTION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+        ),
+        stage_prefix="ttc_bus",
+    ),
+    "ttc_streetcar_delays": TableConfig(
+        table_name="TORONTO_MOBILITY.RAW.TTC_STREETCAR_DELAYS",
+        columns=(
+            "DATE",
+            "ROUTE",
+            "TIME",
+            "DAY",
+            "LOCATION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+            "MIN_GAP",
+            "DIRECTION",
+        ),
+        natural_keys=(
+            "DATE",
+            "TIME",
+            "ROUTE",
+            "DIRECTION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+        ),
+        stage_prefix="ttc_streetcar",
+    ),
+    "bike_share_ridership": TableConfig(
+        table_name="TORONTO_MOBILITY.RAW.BIKE_SHARE_TRIPS",
+        columns=(
+            "TRIP_ID",
+            "TRIP_DURATION",
+            "START_STATION_ID",
+            "START_TIME",
+            "START_STATION_NAME",
+            "END_STATION_ID",
+            "END_TIME",
+            "END_STATION_NAME",
+            "BIKE_ID",
+            "USER_TYPE",
+        ),
+        natural_keys=("TRIP_ID",),
+        stage_prefix="bike_share",
+    ),
+    "weather_daily": TableConfig(
+        table_name="TORONTO_MOBILITY.RAW.WEATHER_DAILY",
+        columns=(
+            "LONGITUDE",
+            "LATITUDE",
+            "STATION_NAME",
+            "CLIMATE_ID",
+            "DATE_TIME",
+            "YEAR",
+            "MONTH",
+            "DAY",
+            "DATA_QUALITY",
+            "MAX_TEMP_C",
+            "MAX_TEMP_FLAG",
+            "MIN_TEMP_C",
+            "MIN_TEMP_FLAG",
+            "MEAN_TEMP_C",
+            "MEAN_TEMP_FLAG",
+            "HEAT_DEG_DAYS_C",
+            "HEAT_DEG_DAYS_FLAG",
+            "COOL_DEG_DAYS_C",
+            "COOL_DEG_DAYS_FLAG",
+            "TOTAL_RAIN_MM",
+            "TOTAL_RAIN_FLAG",
+            "TOTAL_SNOW_CM",
+            "TOTAL_SNOW_FLAG",
+            "TOTAL_PRECIP_MM",
+            "TOTAL_PRECIP_FLAG",
+            "SNOW_ON_GRND_CM",
+            "SNOW_ON_GRND_FLAG",
+            "DIR_OF_MAX_GUST_10S_DEG",
+            "DIR_OF_MAX_GUST_FLAG",
+            "SPD_OF_MAX_GUST_KMH",
+            "SPD_OF_MAX_GUST_FLAG",
+        ),
+        natural_keys=("DATE_TIME",),
+        stage_prefix="weather",
+    ),
+}
+
+
+def get_table_config(dataset_name: str) -> TableConfig:
+    """Look up table configuration for a dataset.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+
+    Returns:
+        Corresponding TableConfig instance.
+
+    Raises:
+        KeyError: If no configuration exists for the dataset.
+    """
+    config = TABLE_CONFIGS.get(dataset_name)
+    if config is None:
+        valid = ", ".join(TABLE_CONFIGS)
+        raise KeyError(f"Unknown dataset '{dataset_name}'. Valid: {valid}")
+    return config
+
+
+# ---- Connection manager (S002) ----------------------------------------------
+
+
+class SnowflakeConnectionManager:
+    """Manage Snowflake connections with layered credential resolution.
+
+    Credential resolution order:
+      1. Explicit constructor arguments
+      2. Environment variables (SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER,
+         SNOWFLAKE_PASSWORD)
+      3. ``~/.snowflake/connections.toml`` ``[loader]`` section
+
+    Implements the context manager protocol to guarantee connection
+    cleanup on scope exit.
+    """
+
+    def __init__(
+        self,
+        *,
+        account: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        role: str = _DEFAULT_ROLE,
+        warehouse: str = _DEFAULT_WAREHOUSE,
+        database: str = _DEFAULT_DATABASE,
+        schema: str = _DEFAULT_SCHEMA,
+    ) -> None:
+        self._account = account
+        self._user = user
+        self._password = password
+        self._role = role
+        self._warehouse = warehouse
+        self._database = database
+        self._schema = schema
+        self._connection: SnowflakeConnection | None = None
+
+    def _resolve_credentials(self) -> dict[str, str]:
+        """Resolve Snowflake credentials from available sources."""
+        import os
+
+        account = self._account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
+        user = self._user or os.environ.get("SNOWFLAKE_USER", "")
+        password = self._password or os.environ.get("SNOWFLAKE_PASSWORD", "")
+
+        if account and user and password:
+            return {"account": account, "user": user, "password": password}
+
+        toml_path = Path.home() / ".snowflake" / "connections.toml"
+        if toml_path.exists():
+            with toml_path.open("rb") as fh:
+                config = tomllib.load(fh)
+            loader = config.get("loader", {})
+            account = account or str(loader.get("account", ""))
+            user = user or str(loader.get("user", ""))
+            password = password or str(loader.get("password", ""))
+            if account and user and password:
+                return {
+                    "account": account,
+                    "user": user,
+                    "password": password,
+                }
+
+        raise LoadError(
+            "Snowflake credentials not found. Set SNOWFLAKE_ACCOUNT, "
+            "SNOWFLAKE_USER, and SNOWFLAKE_PASSWORD environment variables "
+            "or configure ~/.snowflake/connections.toml with a [loader] section."
+        )
+
+    def connect(self) -> SnowflakeConnection:
+        """Establish an authenticated Snowflake connection.
+
+        Returns:
+            Active SnowflakeConnection scoped to LOADER_ROLE.
+
+        Raises:
+            LoadError: On authentication or network failure.
+        """
+        credentials = self._resolve_credentials()
+        try:
+            conn: SnowflakeConnection = snowflake.connector.connect(
+                account=credentials["account"],
+                user=credentials["user"],
+                password=credentials["password"],
+                role=self._role,
+                warehouse=self._warehouse,
+                database=self._database,
+                schema=self._schema,
+                client_session_keep_alive=True,
+                login_timeout=_LOGIN_TIMEOUT,
+                network_timeout=_NETWORK_TIMEOUT,
+            )
+        except snowflake.connector.errors.Error as exc:
+            errno = getattr(exc, "errno", "unknown")
+            msg = getattr(exc, "msg", str(exc))
+            raise LoadError(
+                f"Snowflake connection failed: {msg} (error code: {errno})"
+            ) from exc
+        self._connection = conn
+        return conn
+
+    def __enter__(self) -> SnowflakeConnection:
+        """Enter context manager; return authenticated connection."""
+        return self.connect()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit context manager; close connection unconditionally."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+
+# ---- Stage upload (S003) -----------------------------------------------------
+
+
+def upload_to_stage(
+    connection: SnowflakeConnection,
+    local_path: Path,
+    stage_path: str,
+) -> StageUploadResult:
+    """Upload a local CSV file to the Snowflake internal stage via PUT.
+
+    Args:
+        connection: Active Snowflake connection.
+        local_path: Absolute path to the CSV file on disk.
+        stage_path: Relative destination path within the stage.
+
+    Returns:
+        StageUploadResult with upload status and size metrics.
+
+    Raises:
+        LoadError: If the PUT command fails.
+    """
+    start = time.monotonic()
+    source_size = local_path.stat().st_size
+
+    put_sql = (
+        f"PUT 'file://{local_path}' "
+        f"'{_STAGE_PATH}/{stage_path}' "
+        f"AUTO_COMPRESS=TRUE OVERWRITE=TRUE"
+    )
+
+    cursor = connection.cursor()
+    try:
+        cursor.execute(put_sql)
+        results = list(cursor.fetchall())
+    except snowflake.connector.errors.Error as exc:
+        raise LoadError(
+            f"PUT failed for {local_path}: {getattr(exc, 'msg', str(exc))}",
+            file_path=str(local_path),
+        ) from exc
+    finally:
+        cursor.close()
+
+    elapsed = time.monotonic() - start
+
+    status = StageUploadStatus.UPLOADED
+    dest_size = 0
+    if results:
+        row = tuple(results[0])
+        status_str = str(row[6]).upper() if len(row) > 6 else ""
+        if status_str == "SKIPPED":
+            status = StageUploadStatus.SKIPPED
+        dest_size = int(row[3]) if len(row) > 3 and row[3] else 0
+
+    logger.info(
+        "PUT %s -> %s/%s [%s, %.1fs]",
+        local_path.name,
+        _STAGE_PATH,
+        stage_path,
+        status.value,
+        elapsed,
+    )
+
+    return StageUploadResult(
+        local_path=local_path,
+        stage_path=stage_path,
+        status=status,
+        source_size_bytes=source_size,
+        dest_size_bytes=dest_size,
+        elapsed_seconds=round(elapsed, 3),
+    )
+
+
+# ---- COPY INTO (S003) -------------------------------------------------------
+
+
+def copy_into_table(
+    connection: SnowflakeConnection,
+    table_name: str,
+    stage_path: str,
+    column_mapping: list[str],
+) -> CopyResult:
+    """Execute COPY INTO to bulk-load staged files into a RAW table.
+
+    Uses positional column mapping: ``$1, $2, ...`` from the staged CSV
+    are mapped to the columns listed in ``column_mapping`` in order.
+
+    Args:
+        connection: Active Snowflake connection.
+        table_name: Fully-qualified target table.
+        stage_path: Stage path pattern (may include wildcards).
+        column_mapping: Target column names in CSV positional order.
+
+    Returns:
+        CopyResult with row counts and error details.
+
+    Raises:
+        LoadError: If COPY INTO fails with a row-level or statement error.
+    """
+    start = time.monotonic()
+
+    cols = ", ".join(column_mapping)
+    positional = ", ".join(f"${i}" for i in range(1, len(column_mapping) + 1))
+
+    copy_sql = (
+        f"COPY INTO {table_name} ({cols}) "
+        f"FROM (SELECT {positional} FROM {_STAGE_PATH}/{stage_path}) "
+        f"ON_ERROR = 'ABORT_STATEMENT' "
+        f"PURGE = FALSE"
+    )
+
+    cursor = connection.cursor()
+    try:
+        cursor.execute(copy_sql)
+        results = list(cursor.fetchall())
+    except snowflake.connector.errors.Error as exc:
+        raise LoadError(
+            f"COPY INTO {table_name} failed: {getattr(exc, 'msg', str(exc))}",
+            table=table_name,
+            file_path=stage_path,
+        ) from exc
+    finally:
+        cursor.close()
+
+    elapsed = time.monotonic() - start
+
+    rows_loaded = 0
+    rows_parsed = 0
+    errors_seen = 0
+    first_error: str | None = None
+
+    for raw_row in results:
+        # COPY INTO result columns: file, status, rows_parsed, rows_loaded,
+        # error_limit, errors_seen, first_error, first_error_line, ...
+        row = tuple(raw_row)
+        if len(row) >= 4:
+            rows_parsed += int(row[2]) if row[2] else 0
+            rows_loaded += int(row[3]) if row[3] else 0
+        if len(row) >= 7:
+            errors_seen += int(row[5]) if row[5] else 0
+            if not first_error and row[6]:
+                first_error = str(row[6])
+
+    logger.info(
+        "COPY INTO %s: %d rows loaded (%.1fs)",
+        table_name,
+        rows_loaded,
+        elapsed,
+    )
+
+    return CopyResult(
+        table_name=table_name,
+        rows_loaded=rows_loaded,
+        rows_parsed=rows_parsed,
+        errors_seen=errors_seen,
+        first_error=first_error,
+        elapsed_seconds=round(elapsed, 3),
+    )
+
+
+# ---- MERGE upsert (S004) ----------------------------------------------------
+
+
+def merge_into_table(
+    connection: SnowflakeConnection,
+    target_table: str,
+    natural_keys: list[str],
+    all_columns: list[str],
+    *,
+    stage_path: str,
+    column_mapping: list[str],
+) -> MergeResult:
+    """Execute an idempotent MERGE upsert from staged files into target.
+
+    Creates a session-scoped temporary table with identical DDL to the
+    target, loads staged data via COPY INTO, then MERGEs into the target
+    using the specified natural keys. The temporary table is dropped in
+    all code paths.
+
+    Args:
+        connection: Active Snowflake connection.
+        target_table: Fully-qualified target table.
+        natural_keys: Columns forming the deduplication key.
+        all_columns: All columns in the target table.
+        stage_path: Stage path for COPY INTO the temporary table.
+        column_mapping: Column names in CSV positional order for COPY.
+
+    Returns:
+        MergeResult with insert/update counts.
+
+    Raises:
+        LoadError: If COPY INTO or MERGE fails.
+    """
+    staging_table = f"{target_table}_STAGING"
+    start = time.monotonic()
+
+    cursor = connection.cursor()
+    try:
+        try:
+            cursor.execute(
+                f"CREATE TEMPORARY TABLE {staging_table} LIKE {target_table}"
+            )
+        except snowflake.connector.errors.Error as exc:
+            raise LoadError(
+                f"Failed to create staging table {staging_table}: "
+                f"{getattr(exc, 'msg', str(exc))}",
+                table=target_table,
+            ) from exc
+
+        _copy_into_staging(cursor, staging_table, stage_path, column_mapping)
+
+        result = _execute_merge(
+            cursor,
+            target_table,
+            staging_table,
+            natural_keys,
+            all_columns,
+        )
+    finally:
+        try:
+            cursor.execute(f"DROP TABLE IF EXISTS {staging_table}")
+        except snowflake.connector.errors.Error:
+            logger.warning("Failed to drop staging table %s", staging_table)
+        cursor.close()
+
+    elapsed = time.monotonic() - start
+
+    logger.info(
+        "MERGE INTO %s: %d inserted, %d updated (%.1fs)",
+        target_table,
+        result[0],
+        result[1],
+        elapsed,
+    )
+
+    return MergeResult(
+        target_table=target_table,
+        rows_inserted=result[0],
+        rows_updated=result[1],
+        elapsed_seconds=round(elapsed, 3),
+    )
+
+
+def _copy_into_staging(
+    cursor: Any,
+    staging_table: str,
+    stage_path: str,
+    column_mapping: list[str],
+) -> None:
+    """COPY INTO the temporary staging table from internal stage."""
+    cols = ", ".join(column_mapping)
+    positional = ", ".join(f"${i}" for i in range(1, len(column_mapping) + 1))
+
+    copy_sql = (
+        f"COPY INTO {staging_table} ({cols}) "
+        f"FROM (SELECT {positional} FROM {_STAGE_PATH}/{stage_path}) "
+        f"ON_ERROR = 'ABORT_STATEMENT' "
+        f"PURGE = FALSE"
+    )
+
+    try:
+        cursor.execute(copy_sql)
+    except snowflake.connector.errors.Error as exc:
+        raise LoadError(
+            f"COPY INTO staging table {staging_table} failed: "
+            f"{getattr(exc, 'msg', str(exc))}",
+            table=staging_table,
+            file_path=stage_path,
+        ) from exc
+
+
+def _execute_merge(
+    cursor: Any,
+    target_table: str,
+    staging_table: str,
+    natural_keys: list[str],
+    all_columns: list[str],
+) -> tuple[int, int]:
+    """Build and execute MERGE statement, return (inserted, updated)."""
+    on_clause = " AND ".join(f"target.{k} = staging.{k}" for k in natural_keys)
+
+    non_key_cols = [c for c in all_columns if c not in natural_keys]
+
+    update_set = ", ".join(f"target.{c} = staging.{c}" for c in non_key_cols)
+
+    insert_cols = ", ".join(all_columns)
+    insert_vals = ", ".join(f"staging.{c}" for c in all_columns)
+
+    merge_sql = (
+        f"MERGE INTO {target_table} AS target "
+        f"USING {staging_table} AS staging "
+        f"ON {on_clause}"
+    )
+
+    if update_set:
+        merge_sql += f" WHEN MATCHED THEN UPDATE SET {update_set}"
+
+    merge_sql += f" WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
+
+    try:
+        cursor.execute(merge_sql)
+    except snowflake.connector.errors.Error as exc:
+        raise LoadError(
+            f"MERGE INTO {target_table} failed: {getattr(exc, 'msg', str(exc))}",
+            table=target_table,
+        ) from exc
+
+    rows_inserted = 0
+    rows_updated = 0
+
+    # Snowflake MERGE returns: number of rows inserted, number of rows updated
+    result = cursor.fetchone()
+    if result:
+        rows_inserted = int(result[0]) if result[0] else 0
+        rows_updated = int(result[1]) if len(result) > 1 and result[1] else 0
+
+    return rows_inserted, rows_updated
+
+
+# ---- Convenience: load a full dataset ----------------------------------------
+
+
+def load_dataset(
+    connection: SnowflakeConnection,
+    dataset_name: str,
+    csv_files: list[Path],
+) -> MergeResult:
+    """Upload and MERGE a set of CSV files for a dataset.
+
+    Orchestrates the full load sequence: PUT each file to stage, then
+    execute a single MERGE from the staged directory into the target table.
+    Callers are responsible for transaction boundaries (BEGIN/COMMIT).
+
+    Args:
+        connection: Active Snowflake connection.
+        dataset_name: Machine-readable dataset identifier.
+        csv_files: Validated CSV file paths to load.
+
+    Returns:
+        MergeResult from the final MERGE operation.
+
+    Raises:
+        LoadError: If any PUT or MERGE operation fails.
+        KeyError: If dataset_name has no table configuration.
+    """
+    config = get_table_config(dataset_name)
+
+    for csv_path in csv_files:
+        stage_dest = f"{config.stage_prefix}/{csv_path.name}"
+        upload_to_stage(connection, csv_path, stage_dest)
+
+    return merge_into_table(
+        connection,
+        target_table=config.table_name,
+        natural_keys=list(config.natural_keys),
+        all_columns=list(config.columns),
+        stage_path=f"{config.stage_prefix}/",
+        column_mapping=list(config.columns),
+    )

--- a/scripts/validate_load.py
+++ b/scripts/validate_load.py
@@ -1,0 +1,159 @@
+"""Row count validation for Snowflake RAW tables against source files.
+
+Connects to Snowflake, executes SELECT COUNT(*) on each RAW table,
+reads source file row counts from validated CSV files, and compares
+with a 1% tolerance threshold. Exits with code 0 if all datasets pass.
+
+Usage:
+    python scripts/validate_load.py
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import sys
+from pathlib import Path
+from typing import Final
+
+from scripts.load import TABLE_CONFIGS, LoadError, SnowflakeConnectionManager
+
+logger: Final[logging.Logger] = logging.getLogger(__name__)
+
+_TOLERANCE_PCT: Final[float] = 1.0
+_VALIDATED_DIR: Final[Path] = Path("data/validated")
+
+_DATASET_SUBDIRS: Final[dict[str, str]] = {
+    "ttc_subway_delays": "ttc_subway",
+    "ttc_bus_delays": "ttc_bus",
+    "ttc_streetcar_delays": "ttc_streetcar",
+    "bike_share_ridership": "bike_share",
+    "weather_daily": "weather",
+}
+
+
+def _count_source_rows(dataset_name: str) -> int:
+    """Count total data rows across all validated CSV files for a dataset.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+
+    Returns:
+        Total row count (excluding header rows).
+    """
+    subdir = _DATASET_SUBDIRS.get(dataset_name, "")
+    validated_dir = _VALIDATED_DIR / subdir
+    if not validated_dir.exists():
+        return 0
+
+    total = 0
+    for csv_path in sorted(validated_dir.rglob("*.csv")):
+        with csv_path.open("r", encoding="utf-8") as fh:
+            reader = csv.reader(fh)
+            next(reader, None)  # skip header
+            total += sum(1 for _ in reader)
+
+    return total
+
+
+def _count_snowflake_rows(
+    dataset_name: str,
+    connection_manager: SnowflakeConnectionManager,
+) -> int:
+    """Query SELECT COUNT(*) from the Snowflake RAW table.
+
+    Args:
+        dataset_name: Machine-readable dataset identifier.
+        connection_manager: Pre-configured connection manager.
+
+    Returns:
+        Row count from the Snowflake table.
+
+    Raises:
+        LoadError: If the query fails.
+    """
+    config = TABLE_CONFIGS[dataset_name]
+    with connection_manager as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(f"SELECT COUNT(*) FROM {config.table_name}")
+            result = cursor.fetchone()
+            return int(result[0]) if result else 0
+        finally:
+            cursor.close()
+
+
+def validate_row_counts() -> bool:
+    """Compare source file row counts against Snowflake table counts.
+
+    Returns:
+        True if all datasets are within the 1% tolerance threshold.
+    """
+    connection_manager = SnowflakeConnectionManager()
+    all_pass = True
+
+    header = (
+        f"{'Dataset':<30} {'Source Rows':>12} {'SF Rows':>12} "
+        f"{'Diff %':>8} {'Status':<8}"
+    )
+    print(f"\n{'=' * 80}")
+    print("Row Count Validation (1% tolerance)")
+    print(f"{'=' * 80}")
+    print(header)
+    print("-" * 80)
+
+    for dataset_name in TABLE_CONFIGS:
+        source_rows = _count_source_rows(dataset_name)
+
+        try:
+            sf_rows = _count_snowflake_rows(dataset_name, connection_manager)
+        except (LoadError, Exception) as exc:
+            print(
+                f"{dataset_name:<30} {source_rows:>12,} {'ERROR':>12} {'N/A':>8} FAIL"
+            )
+            logger.error("Query failed for %s: %s", dataset_name, exc)
+            all_pass = False
+            continue
+
+        if source_rows == 0:
+            diff_pct = 0.0 if sf_rows == 0 else 100.0
+        else:
+            diff_pct = abs(sf_rows - source_rows) / source_rows * 100
+
+        passed = diff_pct <= _TOLERANCE_PCT
+        status = "PASS" if passed else "FAIL"
+        if not passed:
+            all_pass = False
+
+        print(
+            f"{dataset_name:<30} {source_rows:>12,} {sf_rows:>12,} "
+            f"{diff_pct:>7.2f}% {status:<8}"
+        )
+
+    print("-" * 80)
+    overall = "PASS" if all_pass else "FAIL"
+    print(f"Overall: {overall}")
+    print(f"{'=' * 80}\n")
+
+    return all_pass
+
+
+def main() -> int:
+    """CLI entry point for row count validation.
+
+    Returns:
+        Exit code: 0 if all datasets pass, 1 otherwise.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    passed = validate_row_counts()
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup/create_ingestion_stage.sql
+++ b/setup/create_ingestion_stage.sql
@@ -1,0 +1,179 @@
+-- =============================================================================
+-- TORONTO MOBILITY ANALYTICS: INGESTION STAGE & RAW TABLE CREATION
+-- =============================================================================
+-- Epic: E-303 Snowflake Loading & Pipeline Orchestration (Story S001)
+-- Execution Context: SYSADMIN role required for object creation
+-- Idempotent: Yes (IF NOT EXISTS / OR REPLACE patterns)
+-- =============================================================================
+
+USE ROLE SYSADMIN;
+USE DATABASE TORONTO_MOBILITY;
+USE SCHEMA RAW;
+
+-- =============================================================================
+-- SECTION 1: INTERNAL NAMED STAGE
+-- =============================================================================
+-- File format embedded in stage definition per E-303 S001:
+--   CSV with quoted fields, header skip, NULL handling, UTF-8 encoding
+-- =============================================================================
+
+CREATE STAGE IF NOT EXISTS TORONTO_MOBILITY.RAW.INGESTION_STAGE
+    FILE_FORMAT = (
+        TYPE = 'CSV'
+        FIELD_DELIMITER = ','
+        RECORD_DELIMITER = '\n'
+        FIELD_OPTIONALLY_ENCLOSED_BY = '"'
+        SKIP_HEADER = 1
+        NULL_IF = ('', 'NULL', 'null')
+        COMPRESSION = 'AUTO'
+        ENCODING = 'UTF8'
+    )
+    COMMENT = 'Internal stage for CSV file ingestion into RAW schema tables';
+
+-- =============================================================================
+-- SECTION 2: LOADER_ROLE GRANTS ON STAGE
+-- =============================================================================
+
+GRANT USAGE ON STAGE TORONTO_MOBILITY.RAW.INGESTION_STAGE TO ROLE LOADER_ROLE;
+
+-- =============================================================================
+-- SECTION 3: RAW SCHEMA TABLE DEFINITIONS
+-- =============================================================================
+-- All columns are VARCHAR to preserve source data integrity.
+-- Type casting is deferred to the STAGING layer (dbt views).
+-- Column names use UPPER_SNAKE_CASE per Snowflake conventions.
+-- =============================================================================
+
+-- TTC Subway Delays (DESIGN-DOC Section 4.3.1)
+-- Source CSV columns: Date, Time, Day, Station, Code, Min Delay, Min Gap, Bound, Line
+CREATE TABLE IF NOT EXISTS TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS (
+    DATE        VARCHAR,
+    TIME        VARCHAR,
+    DAY         VARCHAR,
+    STATION     VARCHAR,
+    CODE        VARCHAR,
+    MIN_DELAY   VARCHAR,
+    MIN_GAP     VARCHAR,
+    BOUND       VARCHAR,
+    LINE        VARCHAR
+)
+COMMENT = 'TTC subway delay incidents from Toronto Open Data Portal (2019-present)';
+
+-- TTC Bus Delays (DESIGN-DOC Section 4.3.1)
+-- Source CSV columns: Date, Route, Time, Day, Location, Incident, Min Delay, Min Gap, Direction
+-- Column INCIDENT renamed to DELAY_CODE for cross-mode consistency
+CREATE TABLE IF NOT EXISTS TORONTO_MOBILITY.RAW.TTC_BUS_DELAYS (
+    DATE        VARCHAR,
+    ROUTE       VARCHAR,
+    TIME        VARCHAR,
+    DAY         VARCHAR,
+    LOCATION    VARCHAR,
+    DELAY_CODE  VARCHAR,
+    MIN_DELAY   VARCHAR,
+    MIN_GAP     VARCHAR,
+    DIRECTION   VARCHAR
+)
+COMMENT = 'TTC bus delay incidents from Toronto Open Data Portal (2020-present)';
+
+-- TTC Streetcar Delays (DESIGN-DOC Section 4.3.1)
+-- Source CSV columns: Date, Line, Time, Day, Location, Incident, Min Delay, Min Gap, Bound
+-- Columns renamed for cross-mode consistency: Line->ROUTE, Incident->DELAY_CODE, Bound->DIRECTION
+CREATE TABLE IF NOT EXISTS TORONTO_MOBILITY.RAW.TTC_STREETCAR_DELAYS (
+    DATE        VARCHAR,
+    ROUTE       VARCHAR,
+    TIME        VARCHAR,
+    DAY         VARCHAR,
+    LOCATION    VARCHAR,
+    DELAY_CODE  VARCHAR,
+    MIN_DELAY   VARCHAR,
+    MIN_GAP     VARCHAR,
+    DIRECTION   VARCHAR
+)
+COMMENT = 'TTC streetcar delay incidents from Toronto Open Data Portal (2020-present)';
+
+-- Bike Share Trips (DESIGN-DOC Section 4.3.2)
+-- Source CSV columns: Trip Id, Trip  Duration, Start Station Id, Start Time,
+--   Start Station Name, End Station Id, End Time, End Station Name, Bike Id, User Type
+CREATE TABLE IF NOT EXISTS TORONTO_MOBILITY.RAW.BIKE_SHARE_TRIPS (
+    TRIP_ID             VARCHAR,
+    TRIP_DURATION       VARCHAR,
+    START_STATION_ID    VARCHAR,
+    START_TIME          VARCHAR,
+    START_STATION_NAME  VARCHAR,
+    END_STATION_ID      VARCHAR,
+    END_TIME            VARCHAR,
+    END_STATION_NAME    VARCHAR,
+    BIKE_ID             VARCHAR,
+    USER_TYPE           VARCHAR
+)
+COMMENT = 'Bike Share Toronto trip records from Toronto Open Data Portal (2019-present)';
+
+-- Weather Daily (DESIGN-DOC Section 4.3.3)
+-- Environment Canada Historical Climate Data, Station ID 51459 (Toronto Pearson)
+-- All 31 standard daily weather columns preserved for completeness
+CREATE TABLE IF NOT EXISTS TORONTO_MOBILITY.RAW.WEATHER_DAILY (
+    LONGITUDE                   VARCHAR,
+    LATITUDE                    VARCHAR,
+    STATION_NAME                VARCHAR,
+    CLIMATE_ID                  VARCHAR,
+    DATE_TIME                   VARCHAR,
+    YEAR                        VARCHAR,
+    MONTH                       VARCHAR,
+    DAY                         VARCHAR,
+    DATA_QUALITY                VARCHAR,
+    MAX_TEMP_C                  VARCHAR,
+    MAX_TEMP_FLAG               VARCHAR,
+    MIN_TEMP_C                  VARCHAR,
+    MIN_TEMP_FLAG               VARCHAR,
+    MEAN_TEMP_C                 VARCHAR,
+    MEAN_TEMP_FLAG              VARCHAR,
+    HEAT_DEG_DAYS_C             VARCHAR,
+    HEAT_DEG_DAYS_FLAG          VARCHAR,
+    COOL_DEG_DAYS_C             VARCHAR,
+    COOL_DEG_DAYS_FLAG          VARCHAR,
+    TOTAL_RAIN_MM               VARCHAR,
+    TOTAL_RAIN_FLAG             VARCHAR,
+    TOTAL_SNOW_CM               VARCHAR,
+    TOTAL_SNOW_FLAG             VARCHAR,
+    TOTAL_PRECIP_MM             VARCHAR,
+    TOTAL_PRECIP_FLAG           VARCHAR,
+    SNOW_ON_GRND_CM             VARCHAR,
+    SNOW_ON_GRND_FLAG           VARCHAR,
+    DIR_OF_MAX_GUST_10S_DEG     VARCHAR,
+    DIR_OF_MAX_GUST_FLAG        VARCHAR,
+    SPD_OF_MAX_GUST_KMH        VARCHAR,
+    SPD_OF_MAX_GUST_FLAG        VARCHAR
+)
+COMMENT = 'Environment Canada daily weather observations for Toronto Pearson (2019-present)';
+
+-- =============================================================================
+-- SECTION 4: VERIFICATION QUERIES
+-- =============================================================================
+-- Execute as LOADER_ROLE to confirm permissions are correctly configured
+-- =============================================================================
+
+USE ROLE LOADER_ROLE;
+
+-- Verify stage access
+LIST @TORONTO_MOBILITY.RAW.INGESTION_STAGE;
+
+-- Verify all five RAW tables exist
+SELECT TABLE_NAME
+FROM TORONTO_MOBILITY.INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = 'RAW'
+    AND TABLE_NAME IN (
+        'TTC_SUBWAY_DELAYS',
+        'TTC_BUS_DELAYS',
+        'TTC_STREETCAR_DELAYS',
+        'BIKE_SHARE_TRIPS',
+        'WEATHER_DAILY'
+    )
+ORDER BY TABLE_NAME;
+
+-- Verify PUT access: upload a 1-row test CSV, then remove it
+-- Execute the following commands manually to confirm PUT/REMOVE permissions:
+--
+--   PUT file:///tmp/test_stage_access.csv @TORONTO_MOBILITY.RAW.INGESTION_STAGE/test/;
+--   REMOVE @TORONTO_MOBILITY.RAW.INGESTION_STAGE/test/test_stage_access.csv;
+--
+-- Both commands must succeed without permission errors.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,331 @@
+"""Tests for the pipeline orchestrator (scripts/ingest.py).
+
+All Snowflake interactions are mocked. No real connections are made.
+Tests cover pipeline flow, error handling, and CLI behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.download import DownloadError
+from scripts.ingest import (
+    DatasetResult,
+    PipelineResult,
+    main,
+    run_pipeline,
+)
+from scripts.load import DatasetStatus, LoadError, MergeResult, PipelineStage
+from scripts.validate import SchemaValidationError
+
+# ---- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture()
+def validated_csvs(tmp_path: Path) -> Path:
+    """Create a temporary validated CSV directory structure."""
+    for subdir in ("ttc_subway", "ttc_bus", "ttc_streetcar", "bike_share", "weather"):
+        d = tmp_path / subdir
+        d.mkdir(parents=True)
+        csv_path = d / "test_2023.csv"
+        csv_path.write_text("col1,col2\nval1,val2\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def mock_merge_result():
+    """Return a successful MergeResult."""
+    return MergeResult(
+        target_table="TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+        rows_inserted=100,
+        rows_updated=0,
+        elapsed_seconds=1.5,
+    )
+
+
+# ---- Pipeline flow tests (S005) ---------------------------------------------
+
+
+class TestRunPipeline:
+    """Tests for the run_pipeline orchestration function."""
+
+    @patch("scripts.ingest._run_load")
+    @patch("scripts.ingest._run_transform_and_validate")
+    @patch("scripts.ingest._run_download")
+    @patch("scripts.ingest._get_validated_csvs")
+    def test_successful_run_returns_success(
+        self,
+        mock_csvs,
+        mock_download,
+        mock_validate,
+        mock_load,
+        mock_merge_result,
+    ):
+        """Successful pipeline returns PipelineResult with success=True."""
+        mock_csvs.return_value = [Path("test.csv")]
+        mock_load.return_value = mock_merge_result
+
+        result = run_pipeline(datasets=["ttc_subway_delays"])
+
+        assert isinstance(result, PipelineResult)
+        assert result.success is True
+        assert len(result.datasets_processed) == 1
+        assert result.datasets_processed[0].status == DatasetStatus.SUCCESS
+        mock_download.assert_called_once()
+        mock_validate.assert_called_once()
+        mock_load.assert_called_once()
+
+    @patch("scripts.ingest._run_load")
+    @patch("scripts.ingest._run_transform_and_validate")
+    @patch("scripts.ingest._run_download")
+    @patch("scripts.ingest._get_validated_csvs")
+    def test_validation_failure_does_not_block_other_datasets(
+        self,
+        mock_csvs,
+        mock_download,
+        mock_validate,
+        mock_load,
+        mock_merge_result,
+    ):
+        """Validation failure for one dataset allows others to continue."""
+        mock_csvs.return_value = [Path("test.csv")]
+
+        call_count = 0
+
+        def validate_side_effect(name: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            if name == "ttc_subway_delays":
+                raise SchemaValidationError(
+                    file_path=Path("bad.csv"),
+                    expected_columns=["Date"],
+                    actual_columns=["Wrong"],
+                    mismatches=["Missing column: Date"],
+                )
+
+        mock_validate.side_effect = lambda n: validate_side_effect(n)
+        mock_load.return_value = mock_merge_result
+
+        result = run_pipeline(datasets=["ttc_subway_delays", "ttc_bus_delays"])
+
+        assert result.success is False
+        statuses = {r.dataset_name: r.status for r in result.datasets_processed}
+        assert statuses["ttc_subway_delays"] == DatasetStatus.FAILED
+        assert statuses["ttc_bus_delays"] == DatasetStatus.SUCCESS
+
+    @patch("scripts.ingest._run_load")
+    @patch("scripts.ingest._run_transform_and_validate")
+    @patch("scripts.ingest._run_download")
+    @patch("scripts.ingest._get_validated_csvs")
+    def test_load_failure_triggers_rollback(
+        self,
+        mock_csvs,
+        mock_download,
+        mock_validate,
+        mock_load,
+    ):
+        """Load failure marks dataset as FAILED with LOAD stage."""
+        mock_csvs.return_value = [Path("test.csv")]
+        mock_load.side_effect = LoadError("COPY INTO failed", table="TEST_TABLE")
+
+        result = run_pipeline(datasets=["ttc_subway_delays"])
+
+        assert result.success is False
+        ds = result.datasets_processed[0]
+        assert ds.status == DatasetStatus.FAILED
+        assert ds.stage == PipelineStage.LOAD
+        assert "COPY INTO" in ds.error_message
+
+    @patch("scripts.ingest._run_load")
+    @patch("scripts.ingest._run_transform_and_validate")
+    @patch("scripts.ingest._run_download")
+    @patch("scripts.ingest._get_validated_csvs")
+    def test_skip_download_flag(
+        self,
+        mock_csvs,
+        mock_download,
+        mock_validate,
+        mock_load,
+        mock_merge_result,
+    ):
+        """--skip-download flag prevents download stage execution."""
+        mock_csvs.return_value = [Path("test.csv")]
+        mock_load.return_value = mock_merge_result
+
+        result = run_pipeline(
+            datasets=["ttc_subway_delays"],
+            skip_download=True,
+        )
+
+        assert result.success is True
+        mock_download.assert_not_called()
+        mock_validate.assert_called_once()
+        mock_load.assert_called_once()
+
+    @patch("scripts.ingest._run_load")
+    @patch("scripts.ingest._run_transform_and_validate")
+    @patch("scripts.ingest._run_download")
+    @patch("scripts.ingest._get_validated_csvs")
+    def test_download_failure_marks_failed(
+        self,
+        mock_csvs,
+        mock_download,
+        mock_validate,
+        mock_load,
+    ):
+        """Download failure marks dataset FAILED at DOWNLOAD stage."""
+        mock_download.side_effect = DownloadError(
+            url="https://example.com", status_code=500, body="Server Error"
+        )
+
+        result = run_pipeline(datasets=["ttc_subway_delays"])
+
+        assert result.success is False
+        ds = result.datasets_processed[0]
+        assert ds.status == DatasetStatus.FAILED
+        assert ds.stage == PipelineStage.DOWNLOAD
+
+
+# ---- Transaction control tests -----------------------------------------------
+
+
+class TestTransactionControl:
+    """Tests for per-dataset atomic transaction boundaries."""
+
+    @patch("scripts.ingest._get_validated_csvs")
+    @patch("scripts.ingest.SnowflakeConnectionManager")
+    def test_begin_commit_on_success(self, mock_mgr_cls, mock_csvs, tmp_path):
+        """Successful load executes BEGIN and COMMIT."""
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("Date\n2023-01-01\n")
+        mock_csvs.return_value = [csv_path]
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [
+            ("f.csv", "f.gz", 100, 50, "n", "g", "UPLOADED", "")
+        ]
+        mock_cursor.fetchone.return_value = (50, 0)
+
+        mock_mgr = MagicMock()
+        mock_mgr.__enter__ = MagicMock(return_value=mock_conn)
+        mock_mgr.__exit__ = MagicMock(return_value=False)
+        mock_mgr_cls.return_value = mock_mgr
+
+        from scripts.ingest import _run_load
+
+        _run_load("ttc_subway_delays", mock_mgr)
+
+        sqls = [c[0][0] for c in mock_cursor.execute.call_args_list if c[0]]
+        assert any("BEGIN" in s for s in sqls)
+        mock_conn.commit.assert_called_once()
+
+    @patch("scripts.ingest._get_validated_csvs")
+    @patch("scripts.ingest.SnowflakeConnectionManager")
+    def test_rollback_on_failure(self, mock_mgr_cls, mock_csvs, tmp_path):
+        """Failed load executes ROLLBACK."""
+        import snowflake.connector.errors
+
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("Date\n2023-01-01\n")
+        mock_csvs.return_value = [csv_path]
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        # PUT succeeds, then MERGE CREATE TEMP fails
+        call_idx = 0
+
+        def execute_side_effect(sql: str) -> None:
+            nonlocal call_idx
+            call_idx += 1
+            if "CREATE TEMPORARY" in sql:
+                raise snowflake.connector.errors.Error(msg="No permissions")
+
+        mock_cursor.execute.side_effect = execute_side_effect
+        mock_cursor.fetchall.return_value = [
+            ("f.csv", "f.gz", 100, 50, "n", "g", "UPLOADED", "")
+        ]
+
+        mock_mgr = MagicMock()
+        mock_mgr.__enter__ = MagicMock(return_value=mock_conn)
+        mock_mgr.__exit__ = MagicMock(return_value=False)
+        mock_mgr_cls.return_value = mock_mgr
+
+        from scripts.ingest import _run_load
+
+        with pytest.raises(LoadError):
+            _run_load("ttc_subway_delays", mock_mgr)
+
+        mock_conn.rollback.assert_called_once()
+
+
+# ---- CLI tests ---------------------------------------------------------------
+
+
+class TestCLI:
+    """Tests for the command-line interface."""
+
+    @patch("scripts.ingest.run_pipeline")
+    def test_cli_all_flag(self, mock_run):
+        """--all flag runs pipeline for all datasets."""
+        mock_run.return_value = PipelineResult(success=True)
+
+        exit_code = main(["--all"])
+
+        assert exit_code == 0
+        mock_run.assert_called_once_with(
+            datasets=None,
+            skip_download=False,
+        )
+
+    @patch("scripts.ingest.run_pipeline")
+    def test_cli_single_dataset(self, mock_run):
+        """--dataset flag runs pipeline for one dataset."""
+        mock_run.return_value = PipelineResult(success=True)
+
+        exit_code = main(["--dataset", "ttc_subway_delays"])
+
+        assert exit_code == 0
+        mock_run.assert_called_once_with(
+            datasets=["ttc_subway_delays"],
+            skip_download=False,
+        )
+
+    @patch("scripts.ingest.run_pipeline")
+    def test_cli_skip_download(self, mock_run):
+        """--skip-download flag is passed through to run_pipeline."""
+        mock_run.return_value = PipelineResult(success=True)
+
+        exit_code = main(["--all", "--skip-download"])
+
+        assert exit_code == 0
+        mock_run.assert_called_once_with(
+            datasets=None,
+            skip_download=True,
+        )
+
+    @patch("scripts.ingest.run_pipeline")
+    def test_cli_exits_1_on_failure(self, mock_run):
+        """Exit code 1 when any dataset fails."""
+        mock_run.return_value = PipelineResult(
+            datasets_processed=[
+                DatasetResult(
+                    dataset_name="test",
+                    stage=PipelineStage.LOAD,
+                    rows_loaded=0,
+                    elapsed_seconds=1.0,
+                    status=DatasetStatus.FAILED,
+                    error_message="Load failed",
+                ),
+            ],
+            success=False,
+        )
+
+        exit_code = main(["--all"])
+
+        assert exit_code == 1

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,481 @@
+"""Tests for the Snowflake loading module (scripts/load.py).
+
+All Snowflake interactions are mocked via unittest.mock.patch on
+snowflake.connector.connect. No real Snowflake connections are made.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.load import (
+    CopyResult,
+    LoadError,
+    MergeResult,
+    SnowflakeConnectionManager,
+    StageUploadResult,
+    StageUploadStatus,
+    TableConfig,
+    copy_into_table,
+    get_table_config,
+    load_dataset,
+    merge_into_table,
+    upload_to_stage,
+)
+
+# ---- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_connection():
+    """Return a MagicMock that behaves like a SnowflakeConnection."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+    # PUT result columns: source, target, src/dest size, compression, status
+    cursor.fetchall.return_value = [
+        ("file.csv", "file.csv.gz", 1024, 512, "none", "gzip", "UPLOADED", "")
+    ]
+    cursor.fetchone.return_value = None
+    return conn
+
+
+@pytest.fixture()
+def mock_cursor(mock_connection):
+    """Return the cursor mock from the mock connection."""
+    return mock_connection.cursor()
+
+
+@pytest.fixture()
+def sample_csv(tmp_path: Path) -> Path:
+    """Create a small CSV file for upload testing."""
+    csv_path = tmp_path / "test_delays.csv"
+    csv_path.write_text("Date,Time,Day\n2023-01-01,08:00,Monday\n")
+    return csv_path
+
+
+# ---- Connection manager tests (S002) ----------------------------------------
+
+
+class TestSnowflakeConnectionManager:
+    """Tests for credential resolution and connection lifecycle."""
+
+    @patch("scripts.load.snowflake.connector.connect")
+    def test_connect_from_env_vars(self, mock_connect, monkeypatch):
+        """Credentials resolved from environment variables."""
+        monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "test_account")
+        monkeypatch.setenv("SNOWFLAKE_USER", "test_user")
+        monkeypatch.setenv("SNOWFLAKE_PASSWORD", "test_pass")
+
+        mock_connect.return_value = MagicMock()
+        mgr = SnowflakeConnectionManager()
+        conn = mgr.connect()
+
+        mock_connect.assert_called_once()
+        call_kwargs = mock_connect.call_args[1]
+        assert call_kwargs["account"] == "test_account"
+        assert call_kwargs["user"] == "test_user"
+        assert call_kwargs["password"] == "test_pass"
+        assert call_kwargs["role"] == "LOADER_ROLE"
+        assert call_kwargs["warehouse"] == "TRANSFORM_WH"
+        assert call_kwargs["database"] == "TORONTO_MOBILITY"
+        assert call_kwargs["schema"] == "RAW"
+        assert call_kwargs["client_session_keep_alive"] is True
+        assert call_kwargs["login_timeout"] == 30
+        assert call_kwargs["network_timeout"] == 60
+        assert conn is not None
+
+    @patch("scripts.load.snowflake.connector.connect")
+    def test_connect_from_toml(self, mock_connect, tmp_path, monkeypatch):
+        """Credentials resolved from connections.toml when env vars missing."""
+        monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+        monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+        monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+
+        toml_dir = tmp_path / ".snowflake"
+        toml_dir.mkdir()
+        toml_path = toml_dir / "connections.toml"
+        toml_path.write_text(
+            "[loader]\naccount = 'toml_acct'\nuser = 'toml_user'\n"
+            "password = 'toml_pass'\n"
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        mock_connect.return_value = MagicMock()
+
+        mgr = SnowflakeConnectionManager()
+        mgr.connect()
+
+        call_kwargs = mock_connect.call_args[1]
+        assert call_kwargs["account"] == "toml_acct"
+        assert call_kwargs["user"] == "toml_user"
+        assert call_kwargs["password"] == "toml_pass"
+
+    def test_connect_raises_when_no_credentials(self, monkeypatch):
+        """LoadError raised when no credential source is available."""
+        monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+        monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+        monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("/nonexistent_home_dir"))
+
+        mgr = SnowflakeConnectionManager()
+        with pytest.raises(LoadError, match="credentials not found"):
+            mgr.connect()
+
+    @patch("scripts.load.snowflake.connector.connect")
+    def test_context_manager_closes_connection(self, mock_connect, monkeypatch):
+        """Connection is closed when exiting the context manager."""
+        monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+        monkeypatch.setenv("SNOWFLAKE_USER", "user")
+        monkeypatch.setenv("SNOWFLAKE_PASSWORD", "pass")
+
+        mock_conn = MagicMock()
+        mock_connect.return_value = mock_conn
+
+        with SnowflakeConnectionManager() as conn:
+            assert conn is mock_conn
+
+        mock_conn.close.assert_called_once()
+
+    @patch("scripts.load.snowflake.connector.connect")
+    def test_connect_failure_raises_load_error(self, mock_connect, monkeypatch):
+        """LoadError raised with Snowflake error details on failure."""
+        monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+        monkeypatch.setenv("SNOWFLAKE_USER", "user")
+        monkeypatch.setenv("SNOWFLAKE_PASSWORD", "pass")
+
+        import snowflake.connector.errors
+
+        mock_connect.side_effect = snowflake.connector.errors.Error(
+            msg="Auth failed", errno=250001
+        )
+
+        mgr = SnowflakeConnectionManager()
+        with pytest.raises(LoadError, match="connection failed"):
+            mgr.connect()
+
+
+# ---- Upload to stage tests (S003) -------------------------------------------
+
+
+class TestUploadToStage:
+    """Tests for PUT upload functionality."""
+
+    def test_constructs_correct_put_sql(self, mock_connection, sample_csv):
+        """PUT SQL contains file path, stage path, and options."""
+        cursor = mock_connection.cursor()
+
+        upload_to_stage(mock_connection, sample_csv, "ttc_subway/test.csv")
+
+        executed_sql = cursor.execute.call_args[0][0]
+        assert "PUT" in executed_sql
+        assert str(sample_csv) in executed_sql
+        assert "INGESTION_STAGE" in executed_sql
+        assert "AUTO_COMPRESS=TRUE" in executed_sql
+        assert "OVERWRITE=TRUE" in executed_sql
+
+    def test_returns_upload_result(self, mock_connection, sample_csv):
+        """StageUploadResult contains expected fields."""
+        result = upload_to_stage(mock_connection, sample_csv, "ttc_subway/test.csv")
+
+        assert isinstance(result, StageUploadResult)
+        assert result.local_path == sample_csv
+        assert result.stage_path == "ttc_subway/test.csv"
+        assert result.status == StageUploadStatus.UPLOADED
+        assert result.source_size_bytes > 0
+        assert result.elapsed_seconds >= 0
+
+    def test_skipped_status_detected(self, mock_connection, sample_csv):
+        """SKIPPED status from PUT is correctly propagated."""
+        cursor = mock_connection.cursor()
+        cursor.fetchall.return_value = [
+            ("f.csv", "f.csv.gz", 100, 50, "none", "gzip", "SKIPPED", "")
+        ]
+
+        result = upload_to_stage(mock_connection, sample_csv, "test/f.csv")
+        assert result.status == StageUploadStatus.SKIPPED
+
+    def test_put_failure_raises_load_error(self, mock_connection, sample_csv):
+        """LoadError raised when PUT command fails."""
+        import snowflake.connector.errors
+
+        cursor = mock_connection.cursor()
+        cursor.execute.side_effect = snowflake.connector.errors.Error(
+            msg="Stage not found"
+        )
+
+        with pytest.raises(LoadError, match="PUT failed"):
+            upload_to_stage(mock_connection, sample_csv, "bad/path.csv")
+
+
+# ---- COPY INTO tests (S003) -------------------------------------------------
+
+
+class TestCopyIntoTable:
+    """Tests for COPY INTO bulk loading."""
+
+    def test_constructs_correct_copy_sql(self, mock_connection):
+        """COPY INTO SQL contains table, columns, stage path, options."""
+        cursor = mock_connection.cursor()
+        cursor.fetchall.return_value = [
+            ("file.csv", "LOADED", 100, 100, 100, 0, None, None)
+        ]
+
+        copy_into_table(
+            mock_connection,
+            "TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+            "ttc_subway/",
+            ["DATE", "TIME", "STATION"],
+        )
+
+        executed_sql = cursor.execute.call_args[0][0]
+        assert "COPY INTO" in executed_sql
+        assert "TTC_SUBWAY_DELAYS" in executed_sql
+        assert "DATE, TIME, STATION" in executed_sql
+        assert "$1, $2, $3" in executed_sql
+        assert "ON_ERROR = 'ABORT_STATEMENT'" in executed_sql
+        assert "PURGE = FALSE" in executed_sql
+
+    def test_returns_copy_result_with_counts(self, mock_connection):
+        """CopyResult contains parsed row counts from Snowflake response."""
+        cursor = mock_connection.cursor()
+        cursor.fetchall.return_value = [
+            ("file1.csv.gz", "LOADED", 500, 500, 500, 0, None, None),
+            ("file2.csv.gz", "LOADED", 300, 300, 300, 0, None, None),
+        ]
+
+        result = copy_into_table(
+            mock_connection,
+            "TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+            "ttc_subway/",
+            ["DATE", "TIME"],
+        )
+
+        assert isinstance(result, CopyResult)
+        assert result.rows_loaded == 800
+        assert result.rows_parsed == 800
+        assert result.errors_seen == 0
+        assert result.first_error is None
+
+    def test_copy_failure_raises_load_error(self, mock_connection):
+        """LoadError raised when COPY INTO fails."""
+        import snowflake.connector.errors
+
+        cursor = mock_connection.cursor()
+        cursor.execute.side_effect = snowflake.connector.errors.Error(
+            msg="Table does not exist"
+        )
+
+        with pytest.raises(LoadError, match="COPY INTO"):
+            copy_into_table(
+                mock_connection,
+                "BAD_TABLE",
+                "path/",
+                ["COL1"],
+            )
+
+
+# ---- MERGE tests (S004) -----------------------------------------------------
+
+
+class TestMergeIntoTable:
+    """Tests for MERGE-based idempotent upsert."""
+
+    def _setup_merge_cursor(self, mock_connection: MagicMock) -> MagicMock:
+        """Configure cursor for a successful MERGE sequence."""
+        cursor: MagicMock = mock_connection.cursor()
+        # Calls: CREATE TEMP, COPY INTO staging, MERGE, DROP
+        cursor.execute.return_value = None
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = (100, 25)
+        return cursor
+
+    def test_constructs_correct_merge_sql(self, mock_connection):
+        """MERGE SQL contains ON, WHEN MATCHED, WHEN NOT MATCHED."""
+        cursor = self._setup_merge_cursor(mock_connection)
+
+        merge_into_table(
+            mock_connection,
+            target_table="TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+            natural_keys=["DATE", "TIME", "STATION"],
+            all_columns=["DATE", "TIME", "STATION", "CODE", "MIN_DELAY"],
+            stage_path="ttc_subway/",
+            column_mapping=["DATE", "TIME", "STATION", "CODE", "MIN_DELAY"],
+        )
+
+        # Collect all executed SQL statements
+        sqls = [call[0][0] for call in cursor.execute.call_args_list if call[0]]
+
+        # Verify CREATE TEMPORARY TABLE
+        assert any("CREATE TEMPORARY TABLE" in s for s in sqls)
+
+        # Verify COPY INTO staging
+        assert any("COPY INTO" in s and "STAGING" in s for s in sqls)
+
+        # Verify MERGE
+        merge_sqls = [s for s in sqls if "MERGE INTO" in s]
+        assert len(merge_sqls) == 1
+        merge_sql = merge_sqls[0]
+        assert "WHEN MATCHED THEN UPDATE SET" in merge_sql
+        assert "WHEN NOT MATCHED THEN INSERT" in merge_sql
+        assert "target.DATE = staging.DATE" in merge_sql
+        assert "target.CODE = staging.CODE" in merge_sql
+
+        # Verify DROP TABLE in finally block
+        assert any("DROP TABLE IF EXISTS" in s for s in sqls)
+
+    def test_returns_merge_result(self, mock_connection):
+        """MergeResult contains insert and update counts."""
+        self._setup_merge_cursor(mock_connection)
+
+        result = merge_into_table(
+            mock_connection,
+            target_table="TORONTO_MOBILITY.RAW.TTC_SUBWAY_DELAYS",
+            natural_keys=["DATE"],
+            all_columns=["DATE", "CODE"],
+            stage_path="test/",
+            column_mapping=["DATE", "CODE"],
+        )
+
+        assert isinstance(result, MergeResult)
+        assert result.rows_inserted == 100
+        assert result.rows_updated == 25
+        assert result.elapsed_seconds >= 0
+
+    def test_drops_staging_table_on_failure(self, mock_connection):
+        """Temporary table is dropped even when MERGE fails."""
+        import snowflake.connector.errors
+
+        cursor = mock_connection.cursor()
+        call_count = 0
+
+        def side_effect(sql: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            # Fail on the MERGE (third execute call after CREATE and COPY)
+            if "MERGE INTO" in sql:
+                raise snowflake.connector.errors.Error(msg="Merge failed")
+
+        cursor.execute.side_effect = side_effect
+        cursor.fetchall.return_value = []
+
+        with pytest.raises(LoadError, match="MERGE INTO"):
+            merge_into_table(
+                mock_connection,
+                target_table="TORONTO_MOBILITY.RAW.TEST",
+                natural_keys=["ID"],
+                all_columns=["ID", "VAL"],
+                stage_path="test/",
+                column_mapping=["ID", "VAL"],
+            )
+
+        # Verify DROP was attempted (last execute call)
+        last_call = cursor.execute.call_args_list[-1]
+        assert "DROP TABLE IF EXISTS" in last_call[0][0]
+
+    def test_natural_keys_match_design_doc(self):
+        """Table configs use natural keys from DESIGN-DOC Section 6.4."""
+        subway = get_table_config("ttc_subway_delays")
+        assert subway.natural_keys == (
+            "DATE",
+            "TIME",
+            "STATION",
+            "LINE",
+            "CODE",
+            "MIN_DELAY",
+        )
+
+        bus = get_table_config("ttc_bus_delays")
+        assert bus.natural_keys == (
+            "DATE",
+            "TIME",
+            "ROUTE",
+            "DIRECTION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+        )
+
+        streetcar = get_table_config("ttc_streetcar_delays")
+        assert streetcar.natural_keys == (
+            "DATE",
+            "TIME",
+            "ROUTE",
+            "DIRECTION",
+            "DELAY_CODE",
+            "MIN_DELAY",
+        )
+
+        bike = get_table_config("bike_share_ridership")
+        assert bike.natural_keys == ("TRIP_ID",)
+
+        weather = get_table_config("weather_daily")
+        assert weather.natural_keys == ("DATE_TIME",)
+
+
+# ---- Load dataset tests ------------------------------------------------------
+
+
+class TestLoadDataset:
+    """Tests for the high-level load_dataset function."""
+
+    def test_load_dataset_calls_put_and_merge(self, mock_connection, tmp_path):
+        """load_dataset uploads files via PUT and executes MERGE."""
+        cursor = mock_connection.cursor()
+        cursor.fetchall.return_value = [
+            ("f.csv", "f.csv.gz", 100, 50, "none", "gzip", "UPLOADED", "")
+        ]
+        cursor.fetchone.return_value = (50, 0)
+
+        csv1 = tmp_path / "delays_2023.csv"
+        csv1.write_text("Date,Time\n2023-01-01,08:00\n")
+
+        result = load_dataset(mock_connection, "ttc_subway_delays", [csv1])
+
+        assert isinstance(result, MergeResult)
+        sqls = [call[0][0] for call in cursor.execute.call_args_list if call[0]]
+        assert any("PUT" in s for s in sqls)
+        assert any("CREATE TEMPORARY TABLE" in s for s in sqls)
+        assert any("MERGE INTO" in s for s in sqls)
+
+    def test_unknown_dataset_raises_key_error(self, mock_connection):
+        """KeyError raised for unknown dataset names."""
+        with pytest.raises(KeyError, match="Unknown dataset"):
+            load_dataset(mock_connection, "nonexistent", [])
+
+
+# ---- Table config tests -----------------------------------------------------
+
+
+class TestTableConfig:
+    """Tests for table configuration registry."""
+
+    def test_all_five_datasets_configured(self):
+        """All five datasets have table configurations."""
+        expected = {
+            "ttc_subway_delays",
+            "ttc_bus_delays",
+            "ttc_streetcar_delays",
+            "bike_share_ridership",
+            "weather_daily",
+        }
+        for name in expected:
+            config = get_table_config(name)
+            assert isinstance(config, TableConfig)
+            assert config.table_name.startswith("TORONTO_MOBILITY.RAW.")
+
+    def test_subway_config_has_nine_columns(self):
+        """Subway table has 9 columns matching contract."""
+        config = get_table_config("ttc_subway_delays")
+        assert len(config.columns) == 9
+
+    def test_bike_share_config_has_ten_columns(self):
+        """Bike share table has 10 columns matching contract."""
+        config = get_table_config("bike_share_ridership")
+        assert len(config.columns) == 10
+
+    def test_weather_config_has_31_columns(self):
+        """Weather table has 31 columns for all Environment Canada fields."""
+        config = get_table_config("weather_daily")
+        assert len(config.columns) == 31

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,746 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy'",
+    "platform_python_implementation == 'PyPy'",
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/88/de5c2a0ce069973345f9fac81200de5b58f503e231dbd566357a5b8c9109/boto3-1.42.44.tar.gz", hash = "sha256:d5601ea520d30674c1d15791a1f98b5c055e973c775e1d9952ccc09ee5913c4e", size = 112865, upload-time = "2026-02-06T20:28:05.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/fb/0341da1482f7fa256d257cfba89383f6692570b741598d4e26d879b26c57/boto3-1.42.44-py3-none-any.whl", hash = "sha256:32e995b0d56e19422cff22f586f698e8924c792eb00943de9c517ff4607e4e18", size = 140604, upload-time = "2026-02-06T20:28:03.598Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.44"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/ff/54cef2c5ff4e1c77fabc0ed68781e48eb36f33433f82bba3605e9c0e45ce/botocore-1.42.44.tar.gz", hash = "sha256:47ba27360f2afd2c2721545d8909217f7be05fdee16dd8fc0b09589535a0701c", size = 14936071, upload-time = "2026-02-06T20:27:53.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/b45c54abfbb902ff174444a48558f97f9917143bc2e996729220f2631db1/botocore-1.42.44-py3-none-any.whl", hash = "sha256:ba406b9243a20591ee87d53abdb883d46416705cebccb639a7f1c923f9dd82df", size = 14611152, upload-time = "2026-02-06T20:27:49.565Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "45.0.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105, upload-time = "2025-09-01T11:13:59.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799, upload-time = "2025-09-01T11:14:02.517Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504, upload-time = "2025-09-01T11:14:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542, upload-time = "2025-09-01T11:14:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", size = 3889244, upload-time = "2025-09-01T11:14:08.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", size = 4461975, upload-time = "2025-09-01T11:14:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", size = 4209082, upload-time = "2025-09-01T11:14:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397, upload-time = "2025-09-01T11:14:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244, upload-time = "2025-09-01T11:14:14.431Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862, upload-time = "2025-09-01T11:14:16.185Z" },
+    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578, upload-time = "2025-09-01T11:14:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400, upload-time = "2025-09-01T11:14:18.958Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824, upload-time = "2025-09-01T11:14:20.954Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233, upload-time = "2025-09-01T11:14:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075, upload-time = "2025-09-01T11:14:24.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517, upload-time = "2025-09-01T11:14:25.679Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", size = 3882893, upload-time = "2025-09-01T11:14:27.1Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", size = 4450132, upload-time = "2025-09-01T11:14:28.58Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", size = 4204086, upload-time = "2025-09-01T11:14:30.572Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383, upload-time = "2025-09-01T11:14:32.046Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186, upload-time = "2025-09-01T11:14:33.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639, upload-time = "2025-09-01T11:14:35.343Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552, upload-time = "2025-09-01T11:14:36.929Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742, upload-time = "2025-09-01T11:14:38.368Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy'",
+    "platform_python_implementation == 'PyPy'",
+]
+dependencies = [
+    { name = "cffi", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/ee/04cd4314db26ffc951c1ea90bde30dd226880ab9343759d7abbecef377ee/cryptography-46.0.0.tar.gz", hash = "sha256:99f64a6d15f19f3afd78720ad2978f6d8d4c68cd4eb600fab82ab1a7c2071dca", size = 749158, upload-time = "2025-09-16T21:07:49.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/bd/3e935ca6e87dc4969683f5dd9e49adaf2cb5734253d93317b6b346e0bd33/cryptography-46.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:c9c4121f9a41cc3d02164541d986f59be31548ad355a5c96ac50703003c50fb7", size = 7285468, upload-time = "2025-09-16T21:05:52.026Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ee/dd17f412ce64b347871d7752657c5084940d42af4d9c25b1b91c7ee53362/cryptography-46.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f70cbade61a16f5e238c4b0eb4e258d177a2fcb59aa0aae1236594f7b0ae338", size = 4308218, upload-time = "2025-09-16T21:05:55.653Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/53/f0b865a971e4e8b3e90e648b6f828950dea4c221bb699421e82ef45f0ef9/cryptography-46.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d1eccae15d5c28c74b2bea228775c63ac5b6c36eedb574e002440c0bc28750d3", size = 4571982, upload-time = "2025-09-16T21:05:57.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/035be5fd63a98284fd74df9e04156f9fed7aa45cef41feceb0d06cbdadd0/cryptography-46.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1b4fba84166d906a22027f0d958e42f3a4dbbb19c28ea71f0fb7812380b04e3c", size = 4307996, upload-time = "2025-09-16T21:05:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/dbb6d7d0a48b95984e2d4caf0a4c7d6606cea5d30241d984c0c02b47f1b6/cryptography-46.0.0-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:523153480d7575a169933f083eb47b1edd5fef45d87b026737de74ffeb300f69", size = 4015692, upload-time = "2025-09-16T21:06:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/65/48/aafcffdde716f6061864e56a0a5908f08dcb8523dab436228957c8ebd5df/cryptography-46.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:f09a3a108223e319168b7557810596631a8cb864657b0c16ed7a6017f0be9433", size = 4982192, upload-time = "2025-09-16T21:06:03.367Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ab/1e73cfc181afc3054a09e5e8f7753a8fba254592ff50b735d7456d197353/cryptography-46.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c1f6ccd6f2eef3b2eb52837f0463e853501e45a916b3fc42e5d93cf244a4b97b", size = 4603944, upload-time = "2025-09-16T21:06:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/02/d71dac90b77c606c90c366571edf264dc8bd37cf836e7f902253cbf5aa77/cryptography-46.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:80a548a5862d6912a45557a101092cd6c64ae1475b82cef50ee305d14a75f598", size = 4308149, upload-time = "2025-09-16T21:06:07.006Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e6/4dcb67fdc6addf4e319a99c4bed25776cb691f3aa6e0c4646474748816c6/cryptography-46.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6c39fd5cd9b7526afa69d64b5e5645a06e1b904f342584b3885254400b63f1b3", size = 4947449, upload-time = "2025-09-16T21:06:11.244Z" },
+    { url = "https://files.pythonhosted.org/packages/26/04/91e3fad8ee33aa87815c8f25563f176a58da676c2b14757a4d3b19f0253c/cryptography-46.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d5c0cbb2fb522f7e39b59a5482a1c9c5923b7c506cfe96a1b8e7368c31617ac0", size = 4603549, upload-time = "2025-09-16T21:06:13.268Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6e/caf4efadcc8f593cbaacfbb04778f78b6d0dac287b45cec25e5054de38b7/cryptography-46.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6d8945bc120dcd90ae39aa841afddaeafc5f2e832809dc54fb906e3db829dfdc", size = 4435976, upload-time = "2025-09-16T21:06:16.514Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c0/704710f349db25c5b91965c3662d5a758011b2511408d9451126429b6cd6/cryptography-46.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:88c09da8a94ac27798f6b62de6968ac78bb94805b5d272dbcfd5fdc8c566999f", size = 4709447, upload-time = "2025-09-16T21:06:19.246Z" },
+    { url = "https://files.pythonhosted.org/packages/91/5e/ff63bfd27b75adaf75cc2398de28a0b08105f9d7f8193f3b9b071e38e8b9/cryptography-46.0.0-cp311-abi3-win32.whl", hash = "sha256:3738f50215211cee1974193a1809348d33893696ce119968932ea117bcbc9b1d", size = 3058317, upload-time = "2025-09-16T21:06:21.466Z" },
+    { url = "https://files.pythonhosted.org/packages/46/47/4caf35014c4551dd0b43aa6c2e250161f7ffcb9c3918c9e075785047d5d2/cryptography-46.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bbaa5eef3c19c66613317dc61e211b48d5f550db009c45e1c28b59d5a9b7812a", size = 3523891, upload-time = "2025-09-16T21:06:23.856Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/6a0cafb3084a854acf808fccf756cbc9b835d1b99fb82c4a15e2e2ffb404/cryptography-46.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:16b5ac72a965ec9d1e34d9417dbce235d45fa04dac28634384e3ce40dfc66495", size = 2932145, upload-time = "2025-09-16T21:06:25.842Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5f/0cf967a1dc1419d5dde111bd0e22872038199f4e4655539ea6f4da5ad7f1/cryptography-46.0.0-cp314-abi3-macosx_10_9_universal2.whl", hash = "sha256:91585fc9e696abd7b3e48a463a20dda1a5c0eeeca4ba60fa4205a79527694390", size = 7203952, upload-time = "2025-09-16T21:06:28.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9e/d20925af5f0484c5049cf7254c91b79776a9b555af04493de6bdd419b495/cryptography-46.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65e9117ebed5b16b28154ed36b164c20021f3a480e9cbb4b4a2a59b95e74c25d", size = 4293519, upload-time = "2025-09-16T21:06:30.143Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b9/07aec6b183ef0054b5f826ae43f0b4db34c50b56aff18f67babdcc2642a3/cryptography-46.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da7f93551d39d462263b6b5c9056c49f780b9200bf9fc2656d7c88c7bdb9b363", size = 4545583, upload-time = "2025-09-16T21:06:31.914Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/7d25158be8c607e2b9ebda49be762404d675b47df335d0d2a3b979d80213/cryptography-46.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:be7479f9504bfb46628544ec7cb4637fe6af8b70445d4455fbb9c395ad9b7290", size = 4299196, upload-time = "2025-09-16T21:06:33.724Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3f/65c8753c0dbebe769cc9f9d87d52bce8b74e850ef2818c59bfc7e4248663/cryptography-46.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f85e6a7d42ad60024fa1347b1d4ef82c4df517a4deb7f829d301f1a92ded038c", size = 3994419, upload-time = "2025-09-16T21:06:35.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b4/69a271873cfc333a236443c94aa07e0233bc36b384e182da2263703b5759/cryptography-46.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:d349af4d76a93562f1dce4d983a4a34d01cb22b48635b0d2a0b8372cdb4a8136", size = 4960228, upload-time = "2025-09-16T21:06:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e0/ab62ee938b8d17bd1025cff569803cfc1c62dfdf89ffc78df6e092bff35f/cryptography-46.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:35aa1a44bd3e0efc3ef09cf924b3a0e2a57eda84074556f4506af2d294076685", size = 4577257, upload-time = "2025-09-16T21:06:39.998Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/09a581c21da7189676678edd2bd37b64888c88c2d2727f2c3e0350194fba/cryptography-46.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c457ad3f151d5fb380be99425b286167b358f76d97ad18b188b68097193ed95a", size = 4299023, upload-time = "2025-09-16T21:06:42.182Z" },
+    { url = "https://files.pythonhosted.org/packages/af/28/2cb6d3d0d2c8ce8be4f19f4d83956c845c760a9e6dfe5b476cebed4f4f00/cryptography-46.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:399ef4c9be67f3902e5ca1d80e64b04498f8b56c19e1bc8d0825050ea5290410", size = 4925802, upload-time = "2025-09-16T21:06:44.31Z" },
+    { url = "https://files.pythonhosted.org/packages/88/0b/1f31b6658c1dfa04e82b88de2d160e0e849ffb94353b1526dfb3a225a100/cryptography-46.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:378eff89b040cbce6169528f130ee75dceeb97eef396a801daec03b696434f06", size = 4577107, upload-time = "2025-09-16T21:06:46.324Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/af/507de3a1d4ded3068ddef188475d241bfc66563d99161585c8f2809fee01/cryptography-46.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c3648d6a5878fd1c9a22b1d43fa75efc069d5f54de12df95c638ae7ba88701d0", size = 4422506, upload-time = "2025-09-16T21:06:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/47/aa/08e514756504d92334cabfe7fe792d10d977f2294ef126b2056b436450eb/cryptography-46.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fc30be952dd4334801d345d134c9ef0e9ccbaa8c3e1bc18925cbc4247b3e29c", size = 4684081, upload-time = "2025-09-16T21:06:49.667Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/ffde6e334fbd4ace04a6d9ced4c5fe1ca9e6ded4ee21b077a6889b452a89/cryptography-46.0.0-cp314-cp314t-win32.whl", hash = "sha256:b8e7db4ce0b7297e88f3d02e6ee9a39382e0efaf1e8974ad353120a2b5a57ef7", size = 3029735, upload-time = "2025-09-16T21:06:51.301Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/78/a41aee8bc5659390806196b0ed4d388211d3b38172827e610a82a7cd7546/cryptography-46.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40ee4ce3c34acaa5bc347615ec452c74ae8ff7db973a98c97c62293120f668c6", size = 3502172, upload-time = "2025-09-16T21:06:53.328Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/7e7427c258fdeae867d236cc9cad0c5c56735bc4d2f4adf035933ab4c15f/cryptography-46.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:07a1be54f995ce14740bf8bbe1cc35f7a37760f992f73cf9f98a2a60b9b97419", size = 2912344, upload-time = "2025-09-16T21:06:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/80e7256a4677c2e9eb762638e8200a51f6dd56d2e3de3e34d0a83c2f5f80/cryptography-46.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:1d2073313324226fd846e6b5fc340ed02d43fd7478f584741bd6b791c33c9fee", size = 7257206, upload-time = "2025-09-16T21:06:59.295Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b8/a5ed987f5c11b242713076121dddfff999d81fb492149c006a579d0e4099/cryptography-46.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83af84ebe7b6e9b6de05050c79f8cc0173c864ce747b53abce6a11e940efdc0d", size = 4301182, upload-time = "2025-09-16T21:07:01.624Z" },
+    { url = "https://files.pythonhosted.org/packages/da/94/f1c1f30110c05fa5247bf460b17acfd52fa3f5c77e94ba19cff8957dc5e6/cryptography-46.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3cd09b1490c1509bf3892bde9cef729795fae4a2fee0621f19be3321beca7e4", size = 4562561, upload-time = "2025-09-16T21:07:03.386Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/54/8decbf2f707350bedcd525833d3a0cc0203d8b080d926ad75d5c4de701ba/cryptography-46.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d14eaf1569d6252280516bedaffdd65267428cdbc3a8c2d6de63753cf0863d5e", size = 4301974, upload-time = "2025-09-16T21:07:04.962Z" },
+    { url = "https://files.pythonhosted.org/packages/82/63/c34a2f3516c6b05801f129616a5a1c68a8c403b91f23f9db783ee1d4f700/cryptography-46.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ab3a14cecc741c8c03ad0ad46dfbf18de25218551931a23bca2731d46c706d83", size = 4009462, upload-time = "2025-09-16T21:07:06.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c5/92ef920a4cf8ff35fcf9da5a09f008a6977dcb9801c709799ec1bf2873fb/cryptography-46.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8e8b222eb54e3e7d3743a7c2b1f7fa7df7a9add790307bb34327c88ec85fe087", size = 4980769, upload-time = "2025-09-16T21:07:08.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8f/1705f7ea3b9468c4a4fef6cce631db14feb6748499870a4772993cbeb729/cryptography-46.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7f3f88df0c9b248dcc2e76124f9140621aca187ccc396b87bc363f890acf3a30", size = 4591812, upload-time = "2025-09-16T21:07:10.288Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b9/2d797ce9d346b8bac9f570b43e6e14226ff0f625f7f6f2f95d9065e316e3/cryptography-46.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9aa85222f03fdb30defabc7a9e1e3d4ec76eb74ea9fe1504b2800844f9c98440", size = 4301844, upload-time = "2025-09-16T21:07:12.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2d/8efc9712997b46aea2ac8f74adc31f780ac4662e3b107ecad0d5c1a0c7f8/cryptography-46.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f9aaf2a91302e1490c068d2f3af7df4137ac2b36600f5bd26e53d9ec320412d3", size = 4943257, upload-time = "2025-09-16T21:07:14.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0c/bc365287a97d28aa7feef8810884831b2a38a8dc4cf0f8d6927ad1568d27/cryptography-46.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:32670ca085150ff36b438c17f2dfc54146fe4a074ebf0a76d72fb1b419a974bc", size = 4591154, upload-time = "2025-09-16T21:07:16.271Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/0b15107277b0c558c02027da615f4e78c892f22c6a04d29c6ad43fcddca6/cryptography-46.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0f58183453032727a65e6605240e7a3824fd1d6a7e75d2b537e280286ab79a52", size = 4428200, upload-time = "2025-09-16T21:07:18.118Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/24/814d69418247ea2cfc985eec6678239013500d745bc7a0a35a32c2e2f3be/cryptography-46.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4bc257c2d5d865ed37d0bd7c500baa71f939a7952c424f28632298d80ccd5ec1", size = 4699862, upload-time = "2025-09-16T21:07:20.219Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1e/665c718e0c45281a4e22454fa8a9bd8835f1ceb667b9ffe807baa41cd681/cryptography-46.0.0-cp38-abi3-win32.whl", hash = "sha256:df932ac70388be034b2e046e34d636245d5eeb8140db24a6b4c2268cd2073270", size = 3043766, upload-time = "2025-09-16T21:07:21.969Z" },
+    { url = "https://files.pythonhosted.org/packages/78/7e/12e1e13abff381c702697845d1cf372939957735f49ef66f2061f38da32f/cryptography-46.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:274f8b2eb3616709f437326185eb563eb4e5813d01ebe2029b61bfe7d9995fbb", size = 3517216, upload-time = "2025-09-16T21:07:24.024Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/55/009497b2ae7375db090b41f9fe7a1a7362f804ddfe17ed9e34f748fcb0e5/cryptography-46.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:249c41f2bbfa026615e7bdca47e4a66135baa81b08509ab240a2e666f6af5966", size = 2923145, upload-time = "2025-09-16T21:07:25.74Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.20.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.7.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", size = 148323, upload-time = "2026-01-14T12:56:16.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/04/79d8fcb43cae376c7adbab7b2b9f65e48432c9eced62ac96703bcc16e09b/librt-0.7.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63", size = 57472, upload-time = "2026-01-14T12:55:08.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ba/60b96e93043d3d659da91752689023a73981336446ae82078cddf706249e/librt-0.7.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93", size = 58986, upload-time = "2026-01-14T12:55:09.466Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/26/5215e4cdcc26e7be7eee21955a7e13cbf1f6d7d7311461a6014544596fac/librt-0.7.8-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592", size = 168422, upload-time = "2026-01-14T12:55:10.499Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/84/e8d1bc86fa0159bfc24f3d798d92cafd3897e84c7fea7fe61b3220915d76/librt-0.7.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850", size = 177478, upload-time = "2026-01-14T12:55:11.577Z" },
+    { url = "https://files.pythonhosted.org/packages/57/11/d0268c4b94717a18aa91df1100e767b010f87b7ae444dafaa5a2d80f33a6/librt-0.7.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62", size = 192439, upload-time = "2026-01-14T12:55:12.7Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/56/1e8e833b95fe684f80f8894ae4d8b7d36acc9203e60478fcae599120a975/librt-0.7.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b", size = 191483, upload-time = "2026-01-14T12:55:13.838Z" },
+    { url = "https://files.pythonhosted.org/packages/17/48/f11cf28a2cb6c31f282009e2208312aa84a5ee2732859f7856ee306176d5/librt-0.7.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714", size = 185376, upload-time = "2026-01-14T12:55:15.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/d7c116c6da561b9155b184354a60a3d5cdbf08fc7f3678d09c95679d13d9/librt-0.7.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449", size = 206234, upload-time = "2026-01-14T12:55:16.571Z" },
+    { url = "https://files.pythonhosted.org/packages/61/de/1975200bb0285fc921c5981d9978ce6ce11ae6d797df815add94a5a848a3/librt-0.7.8-cp312-cp312-win32.whl", hash = "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac", size = 44057, upload-time = "2026-01-14T12:55:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/cd/724f2d0b3461426730d4877754b65d39f06a41ac9d0a92d5c6840f72b9ae/librt-0.7.8-cp312-cp312-win_amd64.whl", hash = "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708", size = 50293, upload-time = "2026-01-14T12:55:19.179Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cf/7e899acd9ee5727ad8160fdcc9994954e79fab371c66535c60e13b968ffc/librt-0.7.8-cp312-cp312-win_arm64.whl", hash = "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0", size = 43574, upload-time = "2026-01-14T12:55:20.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fe/b1f9de2829cf7fc7649c1dcd202cfd873837c5cc2fc9e526b0e7f716c3d2/librt-0.7.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc", size = 57500, upload-time = "2026-01-14T12:55:21.219Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d4/4a60fbe2e53b825f5d9a77325071d61cd8af8506255067bf0c8527530745/librt-0.7.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2", size = 59019, upload-time = "2026-01-14T12:55:22.256Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/37/61ff80341ba5159afa524445f2d984c30e2821f31f7c73cf166dcafa5564/librt-0.7.8-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3", size = 169015, upload-time = "2026-01-14T12:55:23.24Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/86/13d4f2d6a93f181ebf2fc953868826653ede494559da8268023fe567fca3/librt-0.7.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6", size = 178161, upload-time = "2026-01-14T12:55:24.826Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/e24ef01305954fc4d771f1f09f3dd682f9eb610e1bec188ffb719374d26e/librt-0.7.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d", size = 193015, upload-time = "2026-01-14T12:55:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a0/92b6bd060e720d7a31ed474d046a69bd55334ec05e9c446d228c4b806ae3/librt-0.7.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e", size = 192038, upload-time = "2026-01-14T12:55:27.208Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bb/6f4c650253704279c3a214dad188101d1b5ea23be0606628bc6739456624/librt-0.7.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca", size = 186006, upload-time = "2026-01-14T12:55:28.594Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/00/1c409618248d43240cadf45f3efb866837fa77e9a12a71481912135eb481/librt-0.7.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93", size = 206888, upload-time = "2026-01-14T12:55:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/83/b2cfe8e76ff5c1c77f8a53da3d5de62d04b5ebf7cf913e37f8bca43b5d07/librt-0.7.8-cp313-cp313-win32.whl", hash = "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951", size = 44126, upload-time = "2026-01-14T12:55:31.44Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0b/c59d45de56a51bd2d3a401fc63449c0ac163e4ef7f523ea8b0c0dee86ec5/librt-0.7.8-cp313-cp313-win_amd64.whl", hash = "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34", size = 50262, upload-time = "2026-01-14T12:55:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b9/973455cec0a1ec592395250c474164c4a58ebf3e0651ee920fef1a2623f1/librt-0.7.8-cp313-cp313-win_arm64.whl", hash = "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09", size = 43600, upload-time = "2026-01-14T12:55:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/73/fa8814c6ce2d49c3827829cadaa1589b0bf4391660bd4510899393a23ebc/librt-0.7.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418", size = 57049, upload-time = "2026-01-14T12:55:35.056Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fe/f6c70956da23ea235fd2e3cc16f4f0b4ebdfd72252b02d1164dd58b4e6c3/librt-0.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611", size = 58689, upload-time = "2026-01-14T12:55:36.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4d/7a2481444ac5fba63050d9abe823e6bc16896f575bfc9c1e5068d516cdce/librt-0.7.8-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758", size = 166808, upload-time = "2026-01-14T12:55:37.595Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/3c/10901d9e18639f8953f57c8986796cfbf4c1c514844a41c9197cf87cb707/librt-0.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea", size = 175614, upload-time = "2026-01-14T12:55:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/01/5cbdde0951a5090a80e5ba44e6357d375048123c572a23eecfb9326993a7/librt-0.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac", size = 189955, upload-time = "2026-01-14T12:55:39.939Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b4/e80528d2f4b7eaf1d437fcbd6fc6ba4cbeb3e2a0cb9ed5a79f47c7318706/librt-0.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398", size = 189370, upload-time = "2026-01-14T12:55:41.057Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ab/938368f8ce31a9787ecd4becb1e795954782e4312095daf8fd22420227c8/librt-0.7.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81", size = 183224, upload-time = "2026-01-14T12:55:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/10/559c310e7a6e4014ac44867d359ef8238465fb499e7eb31b6bfe3e3f86f5/librt-0.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83", size = 203541, upload-time = "2026-01-14T12:55:43.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/db/a0db7acdb6290c215f343835c6efda5b491bb05c3ddc675af558f50fdba3/librt-0.7.8-cp314-cp314-win32.whl", hash = "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d", size = 40657, upload-time = "2026-01-14T12:55:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e0/4f9bdc2a98a798511e81edcd6b54fe82767a715e05d1921115ac70717f6f/librt-0.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44", size = 46835, upload-time = "2026-01-14T12:55:45.655Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3d/59c6402e3dec2719655a41ad027a7371f8e2334aa794ed11533ad5f34969/librt-0.7.8-cp314-cp314-win_arm64.whl", hash = "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce", size = 39885, upload-time = "2026-01-14T12:55:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/2481d80950b83085fb14ba3c595db56330d21bbc7d88a19f20165f3538db/librt-0.7.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f", size = 59161, upload-time = "2026-01-14T12:55:48.45Z" },
+    { url = "https://files.pythonhosted.org/packages/96/79/108df2cfc4e672336765d54e3ff887294c1cc36ea4335c73588875775527/librt-0.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde", size = 61008, upload-time = "2026-01-14T12:55:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/30179898f9994a5637459d6e169b6abdc982012c0a4b2d4c26f50c06f911/librt-0.7.8-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e", size = 187199, upload-time = "2026-01-14T12:55:50.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/da/f7563db55cebdc884f518ba3791ad033becc25ff68eb70902b1747dc0d70/librt-0.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b", size = 198317, upload-time = "2026-01-14T12:55:51.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6c/4289acf076ad371471fa86718c30ae353e690d3de6167f7db36f429272f1/librt-0.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666", size = 210334, upload-time = "2026-01-14T12:55:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7f/377521ac25b78ac0a5ff44127a0360ee6d5ddd3ce7327949876a30533daa/librt-0.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581", size = 211031, upload-time = "2026-01-14T12:55:54.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/e1e96c3e20b23d00cf90f4aad48f0deb4cdfec2f0ed8380d0d85acf98bbf/librt-0.7.8-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a", size = 204581, upload-time = "2026-01-14T12:55:56.811Z" },
+    { url = "https://files.pythonhosted.org/packages/43/71/0f5d010e92ed9747e14bef35e91b6580533510f1e36a8a09eb79ee70b2f0/librt-0.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca", size = 224731, upload-time = "2026-01-14T12:55:58.175Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", version = "45.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "cryptography", version = "46.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or platform_python_implementation == 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snowflake-connector-python"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "charset-normalizer" },
+    { name = "cryptography", version = "45.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "cryptography", version = "46.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or platform_python_implementation == 'PyPy'" },
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "sortedcontainers" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/df/41fe26b68801e3d59653a5dc7ce87a92e9d967dcad7b59b035b8c9804815/snowflake_connector_python-3.18.0.tar.gz", hash = "sha256:41a46eb9824574c5f8068e3ed5c02a2dc0a733ed08ee81fa1fb3dd0ebe921728", size = 798019, upload-time = "2025-10-06T12:15:34.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/67/0df7829f295988c121f385c562d60c7a4989bc8f72885d04669ce5cd6516/snowflake_connector_python-3.18.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fee7035f865088f948510b094101c8a0e5b22501891f2115f7fb1cb555de76a", size = 1013717, upload-time = "2025-10-06T12:15:41.906Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/90/35353d5311735ebe85f0224f3a6e4f136c29e1b3e4ce6c7466c9b7e7931b/snowflake_connector_python-3.18.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:283366b35df88cd0c71caf0215ba80370ddef4dd37d2adf43b24208c747231ee", size = 1025471, upload-time = "2025-10-06T12:15:43.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/16/d490c00546ca8842d314de689ac718c73c9fe0f9b042e06703449282de7c/snowflake_connector_python-3.18.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e4c285cc6a7f6431cff98c8f235a0fe9da2262462dd3dfc2b97120574a95cf9", size = 2684000, upload-time = "2025-10-06T12:15:23.411Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cb/4bc697af4138e17cccde506f28233492a6e1919ced7a65aa31b6f1e8bb6c/snowflake_connector_python-3.18.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94e041e347b5151b66d19d6cfc3b3172dac1f51e44bbf7cf58f3989427dd464a", size = 2715472, upload-time = "2025-10-06T12:15:25.062Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/72/815a4b9795ddce224a1392849dd34a408f2dac240bcdcb0539d42cfd31b1/snowflake_connector_python-3.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:7116cfa410d517328fd25fabffb54845b88667586718578c4333ce034fead1ba", size = 1160435, upload-time = "2025-10-06T12:15:55.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e6/b75caca8bcfeae1bc999bf70c9cb54a73607f361a3f1ef0b679e2bd850a6/snowflake_connector_python-3.18.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4ed2d593f1983939d5d8d88b212d86fd4f14f0ceefc1df9882b4a18534adbde9", size = 1014849, upload-time = "2025-10-06T12:15:44.228Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/03/0420ebed3b9326e738ab06f8d3f80d9d430054e181ddfe3bf908d87ea5f9/snowflake_connector_python-3.18.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:b99f261c82be92224ac20c8c12bdf26ce3ed5dfd8a3df8a97f15a1e11c46ad27", size = 1026296, upload-time = "2025-10-06T12:15:46.82Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/04/a467a3bc6d59fd77b7628086a32102711cfb337b0920c3dac340a29f27e8/snowflake_connector_python-3.18.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51eb789a09dc6c62119cfabd044fba1a6b8378206f05a1e83ddb2e9cb49acc0b", size = 2685839, upload-time = "2025-10-06T12:15:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/29/70/0ae9d661d405720b7e3bcea425f1915475b457e4a17fec4eb28b8bd91d35/snowflake_connector_python-3.18.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd1de3038b6d7059ca59f93e105aba2a673151c693cc4292f72f38bfaf147df2", size = 2718059, upload-time = "2025-10-06T12:15:27.765Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/38/ea46bbe910bd44ce52aaeea2fefe072392c7c6f3c04bfd0aea3f8fdd5e3a/snowflake_connector_python-3.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:aeeb181a156333480f60b5f8ddbb3d087e288b4509adbef7993236defe4d7570", size = 1160453, upload-time = "2025-10-06T12:15:58.405Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "toronto-mobility-analytics"
+version = "1.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "httpx" },
+    { name = "openpyxl" },
+    { name = "snowflake-connector-python" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "charset-normalizer", specifier = ">=3.3.0,<4.0.0" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0,<2.0.0" },
+    { name = "openpyxl", specifier = ">=3.1.0,<4.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<10.0.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22.0,<1.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0,<1.0.0" },
+    { name = "snowflake-connector-python", specifier = ">=3.12.0,<4.0.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary

- Implement Snowflake loading module with PUT upload, COPY INTO staging, and MERGE-based idempotent upserts with per-dataset natural keys (E-303 S002–S004)
- Add pipeline orchestrator with per-dataset atomic transactions (BEGIN/COMMIT/ROLLBACK), CLI flags (`--all`, `--dataset`, `--skip-download`), and structured execution summary (E-303 S005)
- Add row count validation script comparing source CSV rows against Snowflake with 1% tolerance (E-303 S006)
- Add internal stage DDL and all 5 RAW table definitions with LOADER_ROLE grants (E-303 S001)
- Add 33 tests covering connection management, stage upload, MERGE upserts, transaction control, and CLI behavior (E-303 S007)
- Pin `snowflake-connector-python>=3.12.0,<4.0.0` and add mypy overrides for snowflake/openpyxl stubs

## Execution Evidence

Pipeline executed against live Snowflake instance with all 5 datasets:

| Dataset | Source Rows | Snowflake Rows | Diff | Status |
|---|---|---|---|---|
| ttc_subway_delays | 97,847 | 97,847 | 0.00% | PASS |
| ttc_bus_delays | 245,687 | 245,687 | 0.00% | PASS |
| ttc_streetcar_delays | 63,680 | 63,680 | 0.00% | PASS |
| bike_share_ridership | 21,842,259 | 21,842,259 | 0.00% | PASS |
| weather_daily | 2,922 | 2,922 | 0.00% | PASS |
| **Total** | **22,252,395** | **22,252,395** | **0.00%** | **PASS** |

## Test plan

- [x] `pytest` — 95/95 pass (33 new + 62 existing)
- [x] `mypy --strict` — zero errors
- [x] `ruff check` / `ruff format` — clean
- [x] Protocol Zero scan — no attribution artifacts
- [x] Row count validation — 0% diff across all 5 datasets
- [x] Pre-commit hooks — all passed