### PR TITLE
chore(ci): exclude .venv from Python analysis scope

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,7 +96,8 @@
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.exclude": [
-    "**/dbt_packages/**"
+    "**/dbt_packages/**",
+    "**/.venv/**"
   ],
   // Pylint: disabled — Ruff is the sole linter for this project (CLAUDE.md §6.3)
   "pylint.enabled": false,


### PR DESCRIPTION
## Summary
- Add `**/.venv/**` to `python.analysis.exclude` in VS Code settings to prevent Pylance from indexing virtual environment packages, reducing noise and improving editor performance.

## Linked Issue
Maintenance housekeeping — no linked issue.

## Change Type
- [x] `chore` — Build, CI, or tooling

## Design Impact
- **Architecture Layer:** None (editor configuration only)
- **Schema Changes:** None

## Testing Evidence
- Pre-commit hooks pass (Protocol Zero, trailing whitespace, secrets scan)

## Risk Assessment
- **Low** — Editor-only configuration change with no runtime impact