### PR TITLE
docs(models): add source column descriptions and enable persist_docs (E-901)

### DIFF
--- a/models/marts/core/_core__models.yml
+++ b/models/marts/core/_core__models.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: dim_date
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Calendar date dimension spanning 2019-01-01 through 2026-12-31 (2,922 rows).
       Passthrough from the date_spine seed with type casting: VARCHAR dates to DATE,
@@ -69,6 +73,10 @@ models:
           Labour Day, Thanksgiving, Christmas Day.
 
   - name: dim_station
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Unified station dimension combining 76 canonical TTC subway stations
       (deduplicated from ttc_station_mapping seed) and 1,009 Bike Share Toronto
@@ -126,6 +134,10 @@ models:
           Populated for Bike Share stations; NULL for TTC subway stations.
 
   - name: dim_weather
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Daily weather dimension sourced from stg_weather_daily (Environment Canada
       Toronto City station data). One row per calendar day with temperature,
@@ -212,6 +224,10 @@ models:
               values: ['Snow', 'Rain', 'Clear']
 
   - name: dim_ttc_delay_codes
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       TTC delay incident code lookup dimension with 334 rows. Maps alphanumeric
       delay codes to human-readable descriptions and operational categories.

--- a/models/marts/mobility/_mobility__models.yml
+++ b/models/marts/mobility/_mobility__models.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: fct_transit_delays
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Fact table of TTC delay incidents across subway, bus, and streetcar modes.
       One row per non-zero delay incident with surrogate FK keys to dim_date,
@@ -99,6 +103,10 @@ models:
           Constructed via timestamp_from_parts in the staging layer.
 
   - name: fct_bike_trips
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Fact table of Bike Share Toronto trip records. One row per trip with
       surrogate FK keys to dim_date and dim_station (start and end). Sourced
@@ -192,6 +200,10 @@ models:
           M/DD/YYYY HH24:MI source format in the staging layer.
 
   - name: fct_daily_mobility
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Cross-modal daily aggregation fact table joining transit delay metrics
       and Bike Share ridership metrics via FULL OUTER JOIN on date_key. One row

--- a/models/staging/bike_share/_bike_share__models.yml
+++ b/models/staging/bike_share/_bike_share__models.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: stg_bike_trips
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Staged Bike Share Toronto trip records from RAW.BIKE_SHARE_TRIPS.
       Type-casts VARCHAR columns to native types, generates a surrogate key

--- a/models/staging/bike_share/_bike_share__sources.yml
+++ b/models/staging/bike_share/_bike_share__sources.yml
@@ -21,12 +21,22 @@ sources:
           Grain: one row per trip (trip_id).
         columns:
           - name: TRIP_ID
+            description: Unique trip identifier from the Bike Share Toronto source system.
           - name: TRIP_DURATION
+            description: Duration of the trip in seconds as VARCHAR.
           - name: START_STATION_ID
+            description: Numeric identifier of the trip origin station as VARCHAR.
           - name: START_TIME
+            description: Trip start timestamp in M/DD/YYYY HH24:MI format as VARCHAR.
           - name: START_STATION_NAME
+            description: Display name of the trip origin station.
           - name: END_STATION_ID
+            description: Numeric identifier of the trip destination station as VARCHAR.
           - name: END_TIME
+            description: Trip end timestamp in M/DD/YYYY HH24:MI format as VARCHAR.
           - name: END_STATION_NAME
+            description: Display name of the trip destination station.
           - name: BIKE_ID
+            description: Numeric identifier of the bicycle used as VARCHAR.
           - name: USER_TYPE
+            description: Membership category of the rider (Annual Member or Casual Member).

--- a/models/staging/ttc/_ttc__models.yml
+++ b/models/staging/ttc/_ttc__models.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: stg_ttc_subway_delays
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Staged TTC subway delay incidents from RAW.TTC_SUBWAY_DELAYS.
       Type-casts VARCHAR columns to native types, generates a surrogate key
@@ -90,6 +94,10 @@ models:
               values: ['subway']
 
   - name: stg_ttc_bus_delays
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Staged TTC bus delay incidents from RAW.TTC_BUS_DELAYS.
       Type-casts VARCHAR columns to native types, generates a surrogate key
@@ -166,6 +174,10 @@ models:
               values: ['bus']
 
   - name: stg_ttc_streetcar_delays
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Staged TTC streetcar delay incidents from RAW.TTC_STREETCAR_DELAYS.
       Type-casts VARCHAR columns to native types, generates a surrogate key

--- a/models/staging/ttc/_ttc__sources.yml
+++ b/models/staging/ttc/_ttc__sources.yml
@@ -21,14 +21,23 @@ sources:
           Grain: one row per delay incident (date, time, station, line, code).
         columns:
           - name: DATE
+            description: Date of the subway delay incident in VARCHAR format.
           - name: TIME
+            description: Time of the subway delay incident in VARCHAR format.
           - name: DAY
+            description: Day of the week when the delay occurred.
           - name: STATION
+            description: Name of the TTC subway station where the delay occurred.
           - name: CODE
+            description: TTC incident code identifying the delay cause.
           - name: MIN_DELAY
+            description: Duration of the delay in minutes as VARCHAR.
           - name: MIN_GAP
+            description: Service gap resulting from the delay in minutes as VARCHAR.
           - name: BOUND
+            description: Compass direction of travel (N, S, E, W).
           - name: LINE
+            description: TTC subway line identifier (YU, BD, SHP, SRT).
 
       - name: ttc_bus_delays
         loaded_at_field: "try_cast(date as timestamp)"
@@ -38,14 +47,23 @@ sources:
           Grain: one row per delay incident (date, time, route, direction, delay code).
         columns:
           - name: DATE
+            description: Date of the bus delay incident in VARCHAR format.
           - name: ROUTE
+            description: TTC bus route number or identifier.
           - name: TIME
+            description: Time of the bus delay incident in VARCHAR format.
           - name: DAY
+            description: Day of the week when the delay occurred.
           - name: LOCATION
+            description: Intersection or landmark description of the delay location.
           - name: DELAY_CODE
+            description: TTC incident code identifying the delay cause.
           - name: MIN_DELAY
+            description: Duration of the delay in minutes as VARCHAR.
           - name: MIN_GAP
+            description: Service gap resulting from the delay in minutes as VARCHAR.
           - name: DIRECTION
+            description: Direction of travel at the time of delay.
 
       - name: ttc_streetcar_delays
         loaded_at_field: "try_cast(date as timestamp)"
@@ -55,11 +73,20 @@ sources:
           Grain: one row per delay incident (date, time, route, direction, delay code).
         columns:
           - name: DATE
+            description: Date of the streetcar delay incident in VARCHAR format.
           - name: ROUTE
+            description: TTC streetcar route number or identifier.
           - name: TIME
+            description: Time of the streetcar delay incident in VARCHAR format.
           - name: DAY
+            description: Day of the week when the delay occurred.
           - name: LOCATION
+            description: Intersection or landmark description of the delay location.
           - name: DELAY_CODE
+            description: TTC incident code identifying the delay cause.
           - name: MIN_DELAY
+            description: Duration of the delay in minutes as VARCHAR.
           - name: MIN_GAP
+            description: Service gap resulting from the delay in minutes as VARCHAR.
           - name: DIRECTION
+            description: Direction of travel at the time of delay.

--- a/models/staging/weather/_weather__models.yml
+++ b/models/staging/weather/_weather__models.yml
@@ -2,6 +2,10 @@ version: 2
 
 models:
   - name: stg_weather_daily
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Staged Environment Canada daily weather observations from
       RAW.WEATHER_DAILY (Toronto Pearson, Station ID 51459). Type-casts

--- a/models/staging/weather/_weather__sources.yml
+++ b/models/staging/weather/_weather__sources.yml
@@ -21,33 +21,64 @@ sources:
           Grain: one row per observation date (date_time).
         columns:
           - name: LONGITUDE
+            description: Geographic longitude of the weather station.
           - name: LATITUDE
+            description: Geographic latitude of the weather station.
           - name: STATION_NAME
+            description: Environment Canada weather station name.
           - name: CLIMATE_ID
+            description: Environment Canada climate station identifier.
           - name: DATE_TIME
+            description: Observation date in VARCHAR format.
           - name: YEAR
+            description: Calendar year of the observation.
           - name: MONTH
+            description: Calendar month of the observation.
           - name: DAY
+            description: Calendar day of the observation.
           - name: DATA_QUALITY
+            description: Quality indicator for the observation record.
           - name: MAX_TEMP_C
+            description: Maximum daily temperature in degrees Celsius as VARCHAR.
           - name: MAX_TEMP_FLAG
+            description: Quality flag for maximum temperature reading.
           - name: MIN_TEMP_C
+            description: Minimum daily temperature in degrees Celsius as VARCHAR.
           - name: MIN_TEMP_FLAG
+            description: Quality flag for minimum temperature reading.
           - name: MEAN_TEMP_C
+            description: Mean daily temperature in degrees Celsius as VARCHAR.
           - name: MEAN_TEMP_FLAG
+            description: Quality flag for mean temperature reading.
           - name: HEAT_DEG_DAYS_C
+            description: Heating degree days relative to 18C baseline as VARCHAR.
           - name: HEAT_DEG_DAYS_FLAG
+            description: Quality flag for heating degree days reading.
           - name: COOL_DEG_DAYS_C
+            description: Cooling degree days relative to 18C baseline as VARCHAR.
           - name: COOL_DEG_DAYS_FLAG
+            description: Quality flag for cooling degree days reading.
           - name: TOTAL_RAIN_MM
+            description: Total rainfall in millimeters as VARCHAR.
           - name: TOTAL_RAIN_FLAG
+            description: Quality flag for total rain reading.
           - name: TOTAL_SNOW_CM
+            description: Total snowfall in centimeters as VARCHAR.
           - name: TOTAL_SNOW_FLAG
+            description: Quality flag for total snow reading.
           - name: TOTAL_PRECIP_MM
+            description: Total precipitation in millimeters as VARCHAR.
           - name: TOTAL_PRECIP_FLAG
+            description: Quality flag for total precipitation reading.
           - name: SNOW_ON_GRND_CM
+            description: Snow depth on ground in centimeters as VARCHAR.
           - name: SNOW_ON_GRND_FLAG
+            description: Quality flag for snow on ground reading.
           - name: DIR_OF_MAX_GUST_10S_DEG
+            description: Direction of maximum wind gust in tens of degrees as VARCHAR.
           - name: DIR_OF_MAX_GUST_FLAG
+            description: Quality flag for wind gust direction reading.
           - name: SPD_OF_MAX_GUST_KMH
+            description: Speed of maximum wind gust in km/h as VARCHAR.
           - name: SPD_OF_MAX_GUST_FLAG
+            description: Quality flag for wind gust speed reading.

--- a/seeds/_seeds.yml
+++ b/seeds/_seeds.yml
@@ -2,6 +2,10 @@ version: 2
 
 seeds:
   - name: ttc_station_mapping
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Maps raw TTC station name variants from delay CSVs to canonical
       station names and surrogate keys. Covers 1,101 unique raw name
@@ -39,6 +43,10 @@ seeds:
               values: ['YU', 'BD', 'SHP', 'SRT']
 
   - name: ttc_delay_codes
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Reference mapping of TTC delay incident codes to human-readable
       descriptions and operational categories. Covers 334 codes across
@@ -68,6 +76,10 @@ seeds:
               values: ['Mechanical', 'Signal', 'Passenger', 'Infrastructure', 'Operations', 'Weather', 'Security', 'General']
 
   - name: bike_station_ref
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Bike Share Toronto station reference data sourced from a GBFS
       station_information endpoint snapshot. Provides station identity,
@@ -108,6 +120,10 @@ seeds:
           - not_null
 
   - name: date_spine
+    config:
+      persist_docs:
+        relation: true
+        columns: true
     description: >
       Pre-computed date dimension covering 2019-01-01 through 2026-12-31
       (2,922 rows). Includes calendar attributes and Ontario statutory


### PR DESCRIPTION
## Summary
- Add column-level descriptions to all 68 source columns across 5 RAW tables (TTC subway/bus/streetcar, Bike Share, Weather)
- Enable `persist_docs: {relation: true, columns: true}` on all 12 materialized models and 4 seeds to propagate YAML descriptions as Snowflake `COMMENT ON` metadata
- Complete E-901 documentation audit: 17 models, 4 seeds, 5 sources — 100% column coverage (222 model/seed columns, 68 source columns)

## Linked Issue
Closes #35

## Change Type
- [x] `docs` — Documentation improvements

## Design Impact
- **Architecture Layer:** All layers (staging, marts, seeds, sources)
- **Schema Changes:** None — documentation-only changes to YAML schema files

## Testing Evidence
```
dbt parse                → 0 errors
dbt build                → PASS=177 WARN=5 ERROR=0
dbt docs generate        → Catalog written successfully
Manifest audit           → 21/21 model descriptions, 222/222 column descriptions
Catalog audit (post-build) → 16/16 model/seed entity comments, 150/150 column comments populated
Lineage verification     → 5 rules passed, 24 paths verified, 0 violations
```

## Risk Assessment
- **Risk Level:** Low
- **Rollback Plan:** Revert commit — no SQL logic or model behavior changed

## Governance Checklist
- [x] YAML-only changes within allowed file scope
- [x] No model SQL logic modified
- [x] No new models, tests, or transformations added
- [x] `dbt parse` passes with zero errors
- [x] `dbt build` passes with zero errors (5 pre-existing warnings)
- [x] No AI-attribution breadcrumbs in code or comments
- [x] Commit message follows Conventional Commits standard