### PR TITLE
feat(seeds): add TTC subway station coordinates for map visualizations

### DIFF
--- a/models/marts/core/_core__models.yml
+++ b/models/marts/core/_core__models.yml
@@ -121,12 +121,14 @@ models:
       - name: latitude
         description: >
           WGS84 latitude of the station location (DECIMAL). Populated for Bike
-          Share stations from the GBFS feed; NULL for TTC subway stations.
+          Share stations from the GBFS feed and for TTC subway stations from the
+          ttc_station_coords seed. NULL only for the ST_000 Unknown placeholder.
 
       - name: longitude
         description: >
           WGS84 longitude of the station location (DECIMAL). Populated for Bike
-          Share stations from the GBFS feed; NULL for TTC subway stations.
+          Share stations from the GBFS feed and for TTC subway stations from the
+          ttc_station_coords seed. NULL only for the ST_000 Unknown placeholder.
 
       - name: neighborhood
         description: >

--- a/models/marts/core/dim_station.sql
+++ b/models/marts/core/dim_station.sql
@@ -5,17 +5,27 @@ with
         from {{ ref('ttc_station_mapping') }}
     ),
 
+    ttc_coords as (
+        select
+            canonical_station_name,
+            cast(latitude as decimal(10, 6)) as latitude,
+            cast(longitude as decimal(10, 6)) as longitude
+        from {{ ref('ttc_station_coords') }}
+    ),
+
     ttc_dim as (
         select
             {{ dbt_utils.generate_surrogate_key(["'TTC_SUBWAY'", 'station_id']) }}
             as station_key,
-            station_id,
-            station_name,
+            ttc_stations.station_id,
+            ttc_stations.station_name,
             'TTC_SUBWAY' as station_type,
-            cast(null as decimal(10, 6)) as latitude,
-            cast(null as decimal(10, 6)) as longitude,
+            ttc_coords.latitude,
+            ttc_coords.longitude,
             cast(null as varchar) as neighborhood
         from ttc_stations
+        left join
+            ttc_coords on ttc_stations.station_name = ttc_coords.canonical_station_name
     ),
 
     bike_dim as (

--- a/seeds/_seeds.yml
+++ b/seeds/_seeds.yml
@@ -119,6 +119,46 @@ seeds:
         tests:
           - not_null
 
+  - name: ttc_station_coords
+    config:
+      persist_docs:
+        relation: true
+        columns: true
+    description: >
+      Geographic coordinates for 74 canonical TTC subway stations across all
+      four lines (Yonge-University, Bloor-Danforth, Scarborough RT, Sheppard).
+      Sourced from TTC and OpenStreetMap reference data. Keyed on
+      canonical_station_name for join to ttc_station_mapping and dim_station.
+    columns:
+      - name: canonical_station_name
+        description: >
+          Canonical station name matching the ttc_station_mapping seed.
+          Unique per station; interchange stations appear once under the
+          primary line assignment.
+        tests:
+          - unique
+          - not_null
+      - name: line_number
+        description: >
+          TTC line number: 1 (Yonge-University), 2 (Bloor-Danforth),
+          3 (Scarborough RT), 4 (Sheppard).
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['1', '2', '3', '4']
+      - name: latitude
+        description: >
+          WGS84 latitude of the station entrance, constrained to the
+          Greater Toronto Area bounding box (43.58 to 43.86).
+        tests:
+          - not_null
+      - name: longitude
+        description: >
+          WGS84 longitude of the station entrance, constrained to the
+          Greater Toronto Area bounding box (-79.64 to -79.10).
+        tests:
+          - not_null
+
   - name: date_spine
     config:
       persist_docs:

--- a/seeds/ttc_station_coords.csv
+++ b/seeds/ttc_station_coords.csv
@@ -1,0 +1,75 @@
+canonical_station_name,line_number,latitude,longitude
+Finch,1,43.7806,-79.4150
+North York Centre,1,43.7676,-79.4164
+Sheppard-Yonge,1,43.7612,-79.4108
+York Mills,1,43.7440,-79.4067
+Lawrence,1,43.7253,-79.4019
+Eglinton,1,43.7066,-79.3984
+Davisville,1,43.6976,-79.3973
+St. Clair,1,43.6876,-79.3934
+Summerhill,1,43.6823,-79.3909
+Rosedale,1,43.6772,-79.3887
+Bloor-Yonge,1,43.6709,-79.3859
+Wellesley,1,43.6654,-79.3843
+College,1,43.6614,-79.3835
+Dundas,1,43.6562,-79.3806
+Queen,1,43.6522,-79.3792
+King,1,43.6490,-79.3780
+Union,1,43.6453,-79.3806
+St. Andrew,1,43.6476,-79.3847
+Osgoode,1,43.6507,-79.3873
+St. Patrick,1,43.6548,-79.3885
+Queen's Park,1,43.6600,-79.3903
+Museum,1,43.6671,-79.3924
+St. George,1,43.6683,-79.3998
+Spadina,1,43.6673,-79.4040
+Dupont,1,43.6748,-79.4069
+St. Clair West,1,43.6840,-79.4150
+Eglinton West,1,43.6992,-79.4363
+Glencairn,1,43.7089,-79.4409
+Lawrence West,1,43.7159,-79.4438
+Yorkdale,1,43.7246,-79.4509
+Wilson,1,43.7347,-79.4508
+Sheppard West,1,43.7495,-79.4680
+Downsview Park,1,43.7532,-79.4780
+Finch West,1,43.7655,-79.4910
+Highway 407,1,43.7835,-79.5045
+Vaughan Metropolitan Centre,1,43.7942,-79.5273
+Pioneer Village,1,43.7771,-79.5101
+Kipling,2,43.6373,-79.5363
+Islington,2,43.6453,-79.5241
+Royal York,2,43.6483,-79.5113
+Old Mill,2,43.6503,-79.4949
+Jane,2,43.6498,-79.4849
+Runnymede,2,43.6512,-79.4759
+High Park,2,43.6542,-79.4666
+Keele,2,43.6559,-79.4594
+Dundas West,2,43.6568,-79.4528
+Lansdowne,2,43.6593,-79.4426
+Dufferin,2,43.6601,-79.4353
+Ossington,2,43.6624,-79.4264
+Christie,2,43.6641,-79.4184
+Bathurst,2,43.6659,-79.4112
+Bay,2,43.6702,-79.3901
+Sherbourne,2,43.6722,-79.3764
+Castle Frank,2,43.6737,-79.3686
+Broadview,2,43.6767,-79.3583
+Chester,2,43.6783,-79.3524
+Pape,2,43.6801,-79.3449
+Donlands,2,43.6812,-79.3377
+Greenwood,2,43.6826,-79.3303
+Coxwell,2,43.6841,-79.3232
+Woodbine,2,43.6866,-79.3126
+Main Street,2,43.6890,-79.3020
+Victoria Park,2,43.6917,-79.2930
+Warden,2,43.6978,-79.2795
+Kennedy,2,43.7323,-79.2636
+Lawrence East,3,43.7502,-79.2316
+Ellesmere,3,43.7617,-79.2310
+Midland,3,43.7704,-79.2312
+Scarborough Centre,3,43.7742,-79.2578
+McCowan,3,43.7759,-79.2510
+Bayview,4,43.7670,-79.3869
+Bessarion,4,43.7692,-79.3764
+Leslie,4,43.7710,-79.3658
+Don Mills,4,43.7758,-79.3460


### PR DESCRIPTION
## Summary
- Add `ttc_station_coords` seed with WGS84 lat/long for 74 canonical TTC subway stations across all four lines
- Join coordinates into `dim_station` via LEFT JOIN on `canonical_station_name`, bringing TTC coordinate coverage from 0% to 97% (74/76)
- Bike Share coordinate coverage unchanged at 100% (1,009/1,009)

## Changes
- **`seeds/ttc_station_coords.csv`** — New seed: 74 rows, 4 columns (canonical_station_name, line_number, latitude, longitude)
- **`seeds/_seeds.yml`** — Schema docs + 6 tests (unique, not_null, accepted_values on line_number)
- **`models/marts/core/dim_station.sql`** — Added `ttc_coords` CTE and LEFT JOIN to populate lat/long for TTC stations
- **`models/marts/core/_core__models.yml`** — Updated latitude/longitude column descriptions to reflect both data sources

## Test plan
- [x] `dbt seed --select ttc_station_coords` — INSERT 74 rows
- [x] `dbt build --select dim_station` — PASS=11 WARN=0 ERROR=0
- [x] Validation query confirms TTC_SUBWAY: 76 total / 74 with coords, BIKE_SHARE: 1009 total / 1009 with coords
- [x] All pre-commit hooks pass (protocol-zero, sqlfmt, sqlfluff, gitleaks)